### PR TITLE
Feat: 글 편집, 삭제 기능 추가

### DIFF
--- a/Model/DataModel.swift
+++ b/Model/DataModel.swift
@@ -1,0 +1,15 @@
+//
+//  DataModel.swift
+//  Record
+//
+//  Created by 이지원 on 2022/06/25.
+//
+import SwiftUI
+
+struct UserContent { // 하나의 이야기에 담기는 정보들
+    var music: Music // 음악 정보
+    var lyric: String // 가사
+    var image: Image? // 사진
+    var story: String // 이야기
+
+}

--- a/Record.xcodeproj/project.pbxproj
+++ b/Record.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		876BC4A32857189D009ACC90 /* TestSoiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876BC4A22857189D009ACC90 /* TestSoiView.swift */; };
 		87A0D9B1285BAEF8006D0D3B /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A0D9B0285BAEF8006D0D3B /* Persistence.swift */; };
 		87A0D9B4285BAF42006D0D3B /* Record.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 87A0D9B2285BAF42006D0D3B /* Record.xcdatamodeld */; };
+		87E65F9628670D79007BEA2E /* DataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E65F9528670D79007BEA2E /* DataModel.swift */; };
 		87FB281D285A04680036A5BB /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FB281C285A04680036A5BB /* Screenshot.swift */; };
 		A01413222855F4E60000EA59 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01413212855F4E60000EA59 /* HomeView.swift */; };
 		A0AA39BB285A4936009EE3EA /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AA39BA285A4936009EE3EA /* OnboardingView.swift */; };
@@ -59,6 +60,7 @@
 		876BC4A22857189D009ACC90 /* TestSoiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSoiView.swift; sourceTree = "<group>"; };
 		87A0D9B0285BAEF8006D0D3B /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		87A0D9B3285BAF42006D0D3B /* Recored.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Recored.xcdatamodel; sourceTree = "<group>"; };
+		87E65F9528670D79007BEA2E /* DataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataModel.swift; sourceTree = "<group>"; };
 		87FB281C285A04680036A5BB /* Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screenshot.swift; sourceTree = "<group>"; };
 		A01413212855F4E60000EA59 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		A0AA39BA285A4936009EE3EA /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				87FB281C285A04680036A5BB /* Screenshot.swift */,
 				87A0D9B0285BAEF8006D0D3B /* Persistence.swift */,
 				87A0D9B2285BAF42006D0D3B /* Record.xcdatamodeld */,
+				87E65F9528670D79007BEA2E /* DataModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -231,6 +234,7 @@
 				8715A79F2855B775001AB4F5 /* Extension.swift in Sources */,
 				3D49B5B0285A41570054FDED /* PhotoModalView.swift in Sources */,
 				3D593E472858530B00E481C7 /* WritingModalView.swift in Sources */,
+				87E65F9628670D79007BEA2E /* DataModel.swift in Sources */,
 				B29723B0285B192C0065FD36 /* SnapCarouselView.swift in Sources */,
 				87FB281D285A04680036A5BB /* Screenshot.swift in Sources */,
 				8715A79B2855479E001AB4F5 /* MusicAPI.swift in Sources */,

--- a/Record/CdListView.swift
+++ b/Record/CdListView.swift
@@ -27,7 +27,7 @@ struct CdListView: View {
                 VStack {
                     //TODO: nil일때 보여주는 화면 작성
                     
-                    if items.count != 0 {
+                    if items.count > 0 {
                         SnapCarousel(selection: $selection)
                             .environmentObject(UIStateModel())
                     } else {

--- a/Record/RecordDetailView.swift
+++ b/Record/RecordDetailView.swift
@@ -21,6 +21,7 @@ struct RecordDetailView: View {
     @State private var story = false
     @State private var deleteItemAlert = false // delete item alert
     @State private var saveImage = false
+    @State var clickEdit = false
     
     var body: some View {
         
@@ -123,6 +124,7 @@ struct RecordDetailView: View {
         .navigationBarItems(trailing: Menu(content: {
             
             Button(action: {
+                clickEdit.toggle()
                 
             }) { // TODO: antion내에 편집 기능 예정
                 Label("편집", systemImage: "square.and.pencil")
@@ -160,7 +162,9 @@ struct RecordDetailView: View {
             } message: {  }
         // 본문 ZStack End
         
-        
+            .background(
+                NavigationLink(destination: WriteView(userContent: getUserContent(item), item: item), isActive: $clickEdit){ EmptyView() }.hidden()
+            )
         
     }
     
@@ -172,6 +176,11 @@ struct RecordDetailView: View {
         }catch{
             print(error)
         }
+    }
+    
+    func getUserContent(_ item: Content) -> UserContent {
+        let img = Image(uiImage: UIImage(data: item.image!)!)
+        return UserContent(music: Music(artist: item.artist!, title: item.title!, albumArt: item.albumArt!), lyric: item.lylic ?? "", image: img, story: item.story ?? "")
     }
 }
 

--- a/Record/RecordDetailView.swift
+++ b/Record/RecordDetailView.swift
@@ -21,7 +21,7 @@ struct RecordDetailView: View {
     @Environment(\.managedObjectContext) var managedObjectContext
     @Environment(\.presentationMode) var presentation
     
-    @State var item: Content?
+    //@State var item: Content?
     @State private var photo = false
     @State private var story = false
     @State private var deleteItemAlert = false // delete item alert
@@ -29,6 +29,7 @@ struct RecordDetailView: View {
     @State var clickEdit = false
     @State var isEdit = true
     let index: Int
+    let item: Content
     
     var body: some View {
         
@@ -38,14 +39,16 @@ struct RecordDetailView: View {
             VStack {
                 HStack {
                     VStack(alignment: .leading) {
-                        Text(items[index].title ?? "") // 노래 제목
+                        Text(item.title ?? "") // 노래 제목
+                        //Text("test")
                             .font(.title2)
                             .fontWeight(.bold)
                             .foregroundColor(.titleBlack)
                             .multilineTextAlignment(.leading)
                             .padding(.bottom, 3)
                             
-                        Text(items[index].artist ?? "") // 가수 명
+                        Text(item.artist ?? "") // 가수 명
+                        //Text("Test")
                             .font(.body)
                             .fontWeight(.regular)
                             .foregroundColor(.titleDarkgray)
@@ -69,9 +72,9 @@ struct RecordDetailView: View {
                             Image("DetailPhotoComp") // 이미지
                                 .padding()
                                 .fullScreenCover(isPresented: $photo, onDismiss: { photo = false }, content: {
-                                    PhotoModalView(image: items[index].image!) } )
+                                    PhotoModalView(image: item.image ?? Data()) } )
                             
-                            if let image = items[index].image {
+                            if let image = item.image {
                                 Image(uiImage: UIImage(data: image)!)
                                     .resizable()
                                     .scaledToFill()
@@ -86,9 +89,9 @@ struct RecordDetailView: View {
                     Spacer()
                     
                     CDPlayerComp(music:
-                                    Music(artist: item!.artist ?? "",
-                                          title: item!.title ?? "",
-                                          albumArt: item!.albumArt ?? ""))
+                                    Music(artist: item.artist ?? "",
+                                          title: item.title ?? "",
+                                          albumArt: item.albumArt ?? ""))
                         .offset(x: 25, y: -10)
                 }.offset(y: 80)
                     .padding()
@@ -97,8 +100,7 @@ struct RecordDetailView: View {
                     
                     ZStack {
                         Image("LylicComp") // 가사 입력
-                        //Text(lyric)
-                        Text(item!.lylic ?? "")
+                        Text(item.lylic ?? "")
                             .foregroundColor(.titleDarkgray)
                             .font(.customBody2())
                     }
@@ -114,9 +116,9 @@ struct RecordDetailView: View {
                             Image("StoryComp")
                                 .fullScreenCover(isPresented: $story,
                                                  onDismiss: { story = false },
-                                                 content: { StoryModalView(content: item!.story!) } )
+                                                 content: { StoryModalView(content: items[index].story ?? "") } )
                             
-                            Text(item!.story ?? "") // 이야기
+                            Text(item.story ?? "") // 이야기
                                 .font(Font.customBody2())
                                 .foregroundColor(.titleDarkgray)
                                 .lineLimit(5)
@@ -177,7 +179,7 @@ struct RecordDetailView: View {
         // 편집화면으로 이동
             .fullScreenCover(isPresented: $clickEdit) {
                 NavigationView{
-                    WriteView(userContent: getUserContent(item!), isEdit: $clickEdit, item: $item)
+                    WriteView(userContent: getUserContent(item), isEdit: $clickEdit, item: item)
                         .padding(.top, -40)
                 }
             }
@@ -186,7 +188,7 @@ struct RecordDetailView: View {
     
     
     func deleteItem() {
-        self.managedObjectContext.delete(self.item!)
+            managedObjectContext.delete(items[index])
         do {
             try self.managedObjectContext.save()
             self.presentation.wrappedValue.dismiss()

--- a/Record/RecordDetailView.swift
+++ b/Record/RecordDetailView.swift
@@ -13,7 +13,7 @@ struct RecordDetailView: View {
     
     //coredata 관련 변수
     @Environment(\.managedObjectContext) var managedObjectContext
-    @Environment(\.presentationMode) var presentation: Binding<PresentationMode>
+    @Environment(\.presentationMode) var presentation
     
     let item: Content
     
@@ -151,8 +151,8 @@ struct RecordDetailView: View {
         
         .alert("삭제", isPresented: $deleteItemAlert) {
             Button("삭제", role: .destructive) {
-//                deleteItem()
-//                NavigationUtil.popToRootView()
+                deleteItem()
+                presentation.wrappedValue.dismiss()
             }
         } message: { Text("정말 삭제하시겠습니까?") }
         // 본문 ZStack End
@@ -173,14 +173,15 @@ struct RecordDetailView: View {
         self.managedObjectContext.delete(self.item)
         do {
             try self.managedObjectContext.save()
+            self.presentation.wrappedValue.dismiss()
         }catch{
             print(error)
         }
     }
     
     func getUserContent(_ item: Content) -> UserContent {
-        let img = Image(uiImage: UIImage(data: item.image!)!)
-        return UserContent(music: Music(artist: item.artist!, title: item.title!, albumArt: item.albumArt!), lyric: item.lylic ?? "", image: img, story: item.story ?? "")
+        let img = Image(uiImage: UIImage(data: item.image ?? Data()) ?? UIImage())
+        return UserContent(music: Music(artist: item.artist ?? "", title: item.title ?? "", albumArt: item.albumArt ?? ""), lyric: item.lylic ?? "", image: img, story: item.story ?? "")
     }
 }
 

--- a/Record/SearchView.swift
+++ b/Record/SearchView.swift
@@ -68,7 +68,6 @@ struct SearchView: View {
                             .font(.customBody2())
                     }
                     
-                
                 if search != "" { // X 버튼 활성화
                     Image(systemName: "xmark.circle.fill") // x버튼 이미지
                         .imageScale(.medium)
@@ -110,7 +109,7 @@ struct SearchView: View {
                             .frame(width: 55, height: 55)
                         
                         // 글 작성 페이지로 전환
-                        NavigationLink(destination: WriteView(userContent: UserContent(music: music, lyric: "", image: nil, story: ""), item: nil)) {
+                        NavigationLink(destination: WriteView(userContent: UserContent(music: music, lyric: "", image: nil, story: ""), isEdit: .constant(false), item: .constant(nil))) {
                          
                             // 제목, 가수 출력
                             VStack(alignment: .leading) {

--- a/Record/SearchView.swift
+++ b/Record/SearchView.swift
@@ -110,8 +110,8 @@ struct SearchView: View {
                             .frame(width: 55, height: 55)
                         
                         // 글 작성 페이지로 전환
-                        NavigationLink(destination: WriteView(music: music)) {
-                            
+                        NavigationLink(destination: WriteView(userContent: UserContent(music: music, lyric: "", image: nil, story: ""), item: nil)) {
+                         
                             // 제목, 가수 출력
                             VStack(alignment: .leading) {
                                 Text(music.title) // 노래제목

--- a/Record/SearchView.swift
+++ b/Record/SearchView.swift
@@ -161,6 +161,7 @@ struct URLImage: View {
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .background(.gray)
+                .onAppear() { fetchData() }
             
         } else { // 이미지 불러오기 실패
             

--- a/Record/SearchView.swift
+++ b/Record/SearchView.swift
@@ -109,7 +109,7 @@ struct SearchView: View {
                             .frame(width: 55, height: 55)
                         
                         // 글 작성 페이지로 전환
-                        NavigationLink(destination: WriteView(userContent: UserContent(music: music, lyric: "", image: nil, story: ""), isEdit: .constant(false), item: .constant(nil))) {
+                        NavigationLink(destination: WriteView(userContent: UserContent(music: music, lyric: "", image: nil, story: ""), isEdit: .constant(false), item: nil)) {
                          
                             // 제목, 가수 출력
                             VStack(alignment: .leading) {

--- a/Record/SnapCarouselView.swift
+++ b/Record/SnapCarouselView.swift
@@ -16,7 +16,7 @@ struct SnapCarousel: View {
     @State var value: Int = 0
     @State var selectedCd: Int = 0
     @State var currentCd: Int = 0
-    @State var updateCd = false
+    // @State var updateCd = false
     
     @Binding var selection: Int?
     
@@ -28,46 +28,45 @@ struct SnapCarousel: View {
         // https://gist.github.com/xtabbas/97b44b854e1315384b7d1d5ccce20623.js 의 샘플코드를 참고했습니다.
         return Canvas {
             if items.count > 0 {
-            ZStack {
-                Color("background")
-                    .ignoresSafeArea()
-                // Carousel 슬라이더 기능
-                // ForEach로 items마다 Item() 뷰를 각각 불러옴
-              
-                VStack {
-                  
-                    Carousel(
-                        numberOfItems: CGFloat(items.count),
-                        spacing: spacing,
-                        widthOfHiddenCds: widthOfHiddenCds
-                    ){
-                        ForEach(items.indices, id: \.self) { content in
-                            Item(_id: content){
-                                // 가운데 cd만 글이 보이게 함
-                                
-                                VStack {
-                                    if content == UIState.activeCard {
-                                        Text(items[content].title!)
-                                            .foregroundColor(Color.titleBlack)
-                                            .font(Font.customTitle3())
-                                            .padding(.bottom, 2)
-                                        Text(items[content].artist!)
-                                            .foregroundColor(Color.titleDarkgray)
-                                            .font(Font.customBody2())
-                                            .padding(.bottom, 30)
-                                    } else {
-                                        Spacer()
-                                            .frame(height: 70)
-                                    }
-                                    Spacer()
-                                    // CdPlayer
+                ZStack {
+                    Color("background")
+                        .ignoresSafeArea()
+                    // Carousel 슬라이더 기능
+                    // ForEach로 items마다 Item() 뷰를 각각 불러옴
+                    
+                    VStack {
+                        Carousel(
+                            numberOfItems: CGFloat(items.count),
+                            spacing: spacing,
+                            widthOfHiddenCds: widthOfHiddenCds
+                        ){
+                            ForEach(items.indices, id: \.self) { content in
+                                Item(_id: content){
+                                    // 가운데 cd만 글이 보이게 함
                                     
-                                    ZStack {
-                                        URLImage(urlString: items[content].albumArt!)
-                                            .aspectRatio(contentMode: .fit)
-                                            .clipShape(Circle())
-                                            .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
+                                    VStack {
+                                        if content == UIState.activeCard {
+                                            Text(items[content].title!)
+                                                .foregroundColor(Color.titleBlack)
+                                                .font(Font.customTitle3())
+                                                .padding(.bottom, 2)
+                                            Text(items[content].artist!)
+                                                .foregroundColor(Color.titleDarkgray)
+                                                .font(Font.customBody2())
+                                                .padding(.bottom, 30)
+                                        } else {
+                                            Spacer()
+                                                .frame(height: 70)
+                                        }
+                                        Spacer()
+                                        // CdPlayer
                                         
+                                        ZStack {
+                                            URLImage(urlString: items[content].albumArt!)
+                                                .aspectRatio(contentMode: .fit)
+                                                .clipShape(Circle())
+                                                .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
+                                            
                                             Circle()
                                                 .frame(width: 40, height: 40)
                                                 .foregroundColor(.background)
@@ -77,91 +76,85 @@ struct SnapCarousel: View {
                                                         .shadow(color: .titleDarkgray, radius: 2, x: 3, y: 3)
                                                 )
                                         }
-                                    .disabled(UIState.activeCard != content)
-                                    .onChange(of: UIState.activeCard) { newCd in
-                                        self.currentCd = content
-                                        self.selection = content
-                                        print("changed!!!, \(content), \(UIState.activeCard)")
-                                        self.updateCd.toggle()
-                                       
-                                    }
-                                    
-                                
-                                } // V 스택
+                                        .disabled(UIState.activeCard != content)
+                                        .onChange(of: UIState.activeCard) { newCd in
+                                            self.selection = content
+                                        }
+                                        
+                                        
+                                    } // V 스택
+                                }
+                                .transition(AnyTransition.slide)
+                                .animation(.spring())
                             }
-                            .transition(AnyTransition.slide)
-                            .animation(.spring())
-                        }
-                        .padding(.top, 140)
-                        
-                        
-                    }
-                    VStack {
-                        
-                        Text("CD를 선택하고 플레이어를 재생해보세요")
-                            .foregroundColor(.titleGray)
-                            .font(.customBody2())
-                            .frame(width: 300)
-                            .padding(.bottom, -20)
-                            .padding(.top, 45)
-                        
-                        ZStack {
-                            Image("ListViewCdPlayer")
-                                .offset(y: 30)
+                            .padding(.top, 140)
                             
-                            ForEach(items.indices, id: \.self) { content in
-                                if (content == UIState.activeCard) {
-                                    NavigationLink(destination: RecordDetailView(item: items[UIState.activeCard]), isActive: $showDetailView) {
-                                        URLImage(urlString: items[UIState.activeCard].albumArt!)
-                                            .clipShape(Circle())
-                                            .frame(width: 110, height: 110)
-                                            .rotationEffect(.degrees(self.angle))
-                                            .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
-                                            .onTapGesture {
-                                                self.angle += Double.random(in: 1000..<1980)
-                                                timeCount()
-                                                print(UIState.activeCard)
-                                            }
-                                            .padding(.bottom, 120)
-                                            .padding(.leading, 2) // CdPlayer를 그림자 포함해서 뽑아서 전체 CdPlayer와 정렬 맞추기 위함
+                            
+                        }
+                        VStack {
+                            
+                            Text("CD를 선택하고 플레이어를 재생해보세요")
+                                .foregroundColor(.titleGray)
+                                .font(.customBody2())
+                                .frame(width: 300)
+                                .padding(.bottom, -20)
+                                .padding(.top, 45)
+                            
+                            ZStack {
+                                Image("ListViewCdPlayer")
+                                    .offset(y: 30)
+                                
+                                ForEach(items.indices, id: \.self) { content in
+                                    if content == UIState.activeCard {
+                                        NavigationLink(destination: RecordDetailView(item: items[UIState.activeCard]), isActive: $showDetailView) { // 상세 뷰로 이동
+                                            URLImage(urlString: items[UIState.activeCard].albumArt!)
+                                                .clipShape(Circle())
+                                                .frame(width: 110, height: 110)
+                                                .rotationEffect(.degrees(self.angle))
+                                                .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
+                                                .onTapGesture {
+                                                    self.angle += Double.random(in: 1000..<1980)
+                                                    timeCount()
+                                                }
+                                                .padding(.bottom, 120)
+                                                .padding(.leading, 2) // CdPlayer를 그림자 포함해서 뽑아서 전체 CdPlayer와 정렬 맞추기 위함
+                                        }
                                     }
                                 }
-                            }
-//
-                            // cdPlayer 가운데 원
-                            VStack {
-                                ZStack {
-                                    Circle()
-                                        .foregroundColor(.titleLightgray)
-                                        .frame(width: 30 , height: 30)
-                                    Circle()
-                                        .foregroundColor(.titleDarkgray)
-                                        .frame(width: 15 , height: 15)
-                                        .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
-                                    Circle()
-                                        .foregroundColor(.background)
-                                        .frame(width: 3 , height: 3)
-                                } // Z스택
-                            } // V스택
-                            .padding(.bottom, 120)
-                            .padding(.leading, 4)
-                        } // Z스택
-                    }
-                    
-                    
-                } // V스택
-                .ignoresSafeArea()
-            } // Z스택
+                                // cdPlayer 가운데 원
+                                VStack {
+                                    ZStack {
+                                        Circle()
+                                            .foregroundColor(.titleLightgray)
+                                            .frame(width: 30 , height: 30)
+                                        Circle()
+                                            .foregroundColor(.titleDarkgray)
+                                            .frame(width: 15 , height: 15)
+                                            .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
+                                        Circle()
+                                            .foregroundColor(.background)
+                                            .frame(width: 3 , height: 3)
+                                    } // Z스택
+                                } // V스택
+                                .padding(.bottom, 120)
+                                .padding(.leading, 4)
+                            } // Z스택
+                        }
+                        
+                        
+                    } // V스택
+                    .ignoresSafeArea()
+                } // Z스택
                 
                 .navigationBarTitle("List", displayMode: .inline)
             } else {
                 EmptyView()
-        } // Canvas
-        
-        
-    } // 바디 뷰
+            } // Canvas
+            
+            
+        } // 바디 뷰
     }
-        
+    
     
     
     // 네비게이션 링크로 이동되는 RecordResultView를 딜레이시키고 애니메이션을 보여주기 위한 타임 카운터

--- a/Record/SnapCarouselView.swift
+++ b/Record/SnapCarouselView.swift
@@ -105,8 +105,7 @@ struct SnapCarousel: View {
                                 ForEach(items.indices, id: \.self) { content in
                                     if content == UIState.activeCard {
                                         NavigationLink(destination:
-                                                        RecordDetailView(item: items[UIState.activeCard],
-                                                                         index: UIState.activeCard),
+                                                        RecordDetailView(index: UIState.activeCard, item: items[UIState.activeCard]),
                                                        isActive: $showDetailView) { // 상세 뷰로 이동
                                             
                                             URLImage(urlString: items[UIState.activeCard].albumArt!)

--- a/Record/SnapCarouselView.swift
+++ b/Record/SnapCarouselView.swift
@@ -23,9 +23,7 @@ struct SnapCarousel: View {
     var body: some View {
         let spacing: CGFloat = -10
         let widthOfHiddenCds: CGFloat = 100
-        let cdHeight: CGFloat = 300
-        
-        // https://gist.github.com/xtabbas/97b44b854e1315384b7d1d5ccce20623.js 의 샘플코드를 참고했습니다.
+        //  https://gist.github.com/xtabbas/97b44b854e1315384b7d1d5ccce20623.js 의 샘플코드를 참고했습니다.
         return Canvas {
             if items.count > 0 {
                 ZStack {
@@ -106,7 +104,11 @@ struct SnapCarousel: View {
                                 
                                 ForEach(items.indices, id: \.self) { content in
                                     if content == UIState.activeCard {
-                                        NavigationLink(destination: RecordDetailView(item: items[UIState.activeCard]), isActive: $showDetailView) { // 상세 뷰로 이동
+                                        NavigationLink(destination:
+                                                        RecordDetailView(item: items[UIState.activeCard],
+                                                                         index: UIState.activeCard),
+                                                       isActive: $showDetailView) { // 상세 뷰로 이동
+                                            
                                             URLImage(urlString: items[UIState.activeCard].albumArt!)
                                                 .clipShape(Circle())
                                                 .frame(width: 110, height: 110)

--- a/Record/SnapCarouselView.swift
+++ b/Record/SnapCarouselView.swift
@@ -16,6 +16,7 @@ struct SnapCarousel: View {
     @State var value: Int = 0
     @State var selectedCd: Int = 0
     @State var currentCd: Int = 0
+    @State var updateCd = false
     
     @Binding var selection: Int?
     
@@ -26,6 +27,7 @@ struct SnapCarousel: View {
         
         // https://gist.github.com/xtabbas/97b44b854e1315384b7d1d5ccce20623.js 의 샘플코드를 참고했습니다.
         return Canvas {
+            if items.count > 0 {
             ZStack {
                 Color("background")
                     .ignoresSafeArea()
@@ -44,7 +46,7 @@ struct SnapCarousel: View {
                                 // 가운데 cd만 글이 보이게 함
                                 
                                 VStack {
-                                    if (content == UIState.activeCard) {
+                                    if content == UIState.activeCard {
                                         Text(items[content].title!)
                                             .foregroundColor(Color.titleBlack)
                                             .font(Font.customTitle3())
@@ -57,28 +59,15 @@ struct SnapCarousel: View {
                                         Spacer()
                                             .frame(height: 70)
                                     }
-                                    // cd자체가 버튼으로 기능해 선택된 id값 저장
-                                    Button(action: {
-                                        if self.showCd {
-                                            self.showCd = false
-                                            self.selectedCd = self.currentCd
-                        
-                                                
-                                            
-                                        } else {
-                                            self.showCd = true
-                                            self.selectedCd = content
-                                            self.currentCd = self.selectedCd
-                                        }
-                                            
-                                    }) {
-                                        ZStack {
-                                            URLImage(urlString: items[content].albumArt!)
-                                                .aspectRatio(contentMode: .fit)
-                                                .clipShape(Circle())
-                                                .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
-                                            
-                                            
+                                    Spacer()
+                                    // CdPlayer
+                                    
+                                    ZStack {
+                                        URLImage(urlString: items[content].albumArt!)
+                                            .aspectRatio(contentMode: .fit)
+                                            .clipShape(Circle())
+                                            .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
+                                        
                                             Circle()
                                                 .frame(width: 40, height: 40)
                                                 .foregroundColor(.background)
@@ -87,30 +76,26 @@ struct SnapCarousel: View {
                                                         .stroke(.background, lineWidth: 0.1)
                                                         .shadow(color: .titleDarkgray, radius: 2, x: 3, y: 3)
                                                 )
-//                                            Circle()
-//                                                .fill(.white)
-//                                                .frame(width: 35, height: 35)
-//                                                .shadow(color: .black, radius: 4, x: -4, y: 4)
                                         }
-                                    } // 버튼
                                     .disabled(UIState.activeCard != content)
                                     .onChange(of: UIState.activeCard) { newCd in
-                                        if newCd != selectedCd {
-                                            self.showCd = false
-                                        }
+                                        self.currentCd = content
+                                        self.selection = content
+                                        print("changed!!!, \(content), \(UIState.activeCard)")
+                                        self.updateCd.toggle()
+                                       
                                     }
                                     
+                                
                                 } // V 스택
                             }
                             .transition(AnyTransition.slide)
                             .animation(.spring())
                         }
+                        .padding(.top, 140)
+                        
+                        
                     }
-                    .padding(.top, 140)
-                    
-                    Spacer()
-                    // CdPlayer
-                    
                     VStack {
                         
                         Text("CD를 선택하고 플레이어를 재생해보세요")
@@ -120,68 +105,64 @@ struct SnapCarousel: View {
                             .padding(.bottom, -20)
                             .padding(.top, 45)
                         
-                    ZStack {
-                        Image("ListViewCdPlayer")
-                            .offset(y: 30)
-                        
-                        //cd 클릭시, cdPlayer에 cd 나타남
-                        VStack {
-                            if showCd == true {
-                                NavigationLink(destination: RecordDetailView(item: items[selectedCd]), isActive: $showDetailView) {
-                                    URLImage(urlString: items[selectedCd].albumArt!)
-                                        .clipShape(Circle())
-                                        .frame(width: 110, height: 110)
-                                        .rotationEffect(.degrees(self.angle))
-                                        .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
-                                        .onTapGesture {
-                                            self.angle += Double.random(in: 1000..<1980)
-                                            timeCount()
-                                        }
+                        ZStack {
+                            Image("ListViewCdPlayer")
+                                .offset(y: 30)
+                            
+                            ForEach(items.indices, id: \.self) { content in
+                                if (content == UIState.activeCard) {
+                                    NavigationLink(destination: RecordDetailView(item: items[UIState.activeCard]), isActive: $showDetailView) {
+                                        URLImage(urlString: items[UIState.activeCard].albumArt!)
+                                            .clipShape(Circle())
+                                            .frame(width: 110, height: 110)
+                                            .rotationEffect(.degrees(self.angle))
+                                            .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
+                                            .onTapGesture {
+                                                self.angle += Double.random(in: 1000..<1980)
+                                                timeCount()
+                                                print(UIState.activeCard)
+                                            }
+                                            .padding(.bottom, 120)
+                                            .padding(.leading, 2) // CdPlayer를 그림자 포함해서 뽑아서 전체 CdPlayer와 정렬 맞추기 위함
+                                    }
                                 }
-                            } else {
-                                NavigationLink(destination: RecordDetailView(item: items[selectedCd]), isActive: $showDetailView) {
-                                    URLImage(urlString: items[selectedCd].albumArt!)
-                                        .clipShape(Circle())
-                                        .frame(width: 110, height: 110)
-                                        .rotationEffect(.degrees(self.angle))
-                                        .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
-                                        .onTapGesture {
-                                            self.angle += Double.random(in: 1000..<1980)
-                                            timeCount()
-                                        }
-                                }
-                            } // else문
-                        } // V스택
-                        .padding(.bottom, 120)
-                        .padding(.leading, 2) // CdPlayer를 그림자 포함해서 뽑아서 전체 CdPlayer와 정렬 맞추기 위함
-                        
-                        // cdPlayer 가운데 원
-                        VStack {
-                            ZStack {
-                                Circle()
-                                    .foregroundColor(.titleLightgray)
-                                    .frame(width: 30 , height: 30)
-                                Circle()
-                                    .foregroundColor(.titleDarkgray)
-                                    .frame(width: 15 , height: 15)
-                                    .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
-                                Circle()
-                                    .foregroundColor(.background)
-                                    .frame(width: 3 , height: 3)
-                            } // Z스택
-                        } // V스택
-                        .padding(.bottom, 120)
-                        .padding(.leading, 4)
-                    } // Z스택
-                }
+                            }
+//
+                            // cdPlayer 가운데 원
+                            VStack {
+                                ZStack {
+                                    Circle()
+                                        .foregroundColor(.titleLightgray)
+                                        .frame(width: 30 , height: 30)
+                                    Circle()
+                                        .foregroundColor(.titleDarkgray)
+                                        .frame(width: 15 , height: 15)
+                                        .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
+                                    Circle()
+                                        .foregroundColor(.background)
+                                        .frame(width: 3 , height: 3)
+                                } // Z스택
+                            } // V스택
+                            .padding(.bottom, 120)
+                            .padding(.leading, 4)
+                        } // Z스택
+                    }
+                    
+                    
                 } // V스택
                 .ignoresSafeArea()
             } // Z스택
+                
+                .navigationBarTitle("List", displayMode: .inline)
+            } else {
+                EmptyView()
         } // Canvas
-        .navigationBarTitle("List", displayMode: .inline)
         
         
     } // 바디 뷰
+    }
+        
+    
     
     // 네비게이션 링크로 이동되는 RecordResultView를 딜레이시키고 애니메이션을 보여주기 위한 타임 카운터
     func timeCount() {

--- a/Record/WriteView.swift
+++ b/Record/WriteView.swift
@@ -27,7 +27,7 @@ struct WriteView: View {
     @State private var lyrics = ""
     @State private var content = ""
     @Binding var isEdit: Bool
-    @Binding var item: Content?
+    let item: Content?
     
     var body: some View {
         


### PR DESCRIPTION
## 작업 내용

- 편집, 삭제 기능 구현
- 슬라이드시 CD가 같이 변경되도록 변경
- 삭제 후 이미지가 변경되지 않는 오류 해결

## 리뷰 포인트

- core data를 사용하여 글 수정 및 삭제가 가능하도록 구현하였습니다.
- 수정화면을 fullScreenCover로 구현하였습니다.

## 다음으로 진행될 작업
- [x] 편집 화면에 있다는 것을 알려주기 위해 모달처럼 아래에서 위로 올라오는 형태의 뷰로 만들기

## 결과 화면
|수정 전|수정 후|
|---|---|
|<img width="250" src ="https://user-images.githubusercontent.com/68676844/175812910-2f227c05-6f30-4126-93dd-afe868e95c9d.png">| <img width = "250" src = "https://user-images.githubusercontent.com/68676844/175812946-d6c61b4e-7768-4946-bdcf-3352704bee77.png">

## 질문
- 편집을 눌렀을 때, 사용자가 편집 화면에 있는 것인지 헷갈릴 것이라고 생각합니다. -> FullScreenCover로 띄우기
- ~~현재는 뷰에서는 저장버튼 유무만 차이가 있습니다.~~

## 수정 후 최종 화면
https://user-images.githubusercontent.com/68676844/177398134-38cfc7ac-181f-4856-93f5-ca6a58fda892.mp4