### PR TITLE
[FEAT] #35 - 사진 선택시 키보드가 사라지게 수정, 다크모드일 경우 글자가 흰색으로 보여 라이트 모드만 지원하게 수정

### DIFF
--- a/Record.xcodeproj/project.pbxproj
+++ b/Record.xcodeproj/project.pbxproj
@@ -380,9 +380,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Record/Preview Content\"";
-
 				DEVELOPMENT_TEAM = PK2NRTCS5P;
-
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Record/Info.plist;
@@ -391,6 +389,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -414,9 +413,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Record/Preview Content\"";
-
 				DEVELOPMENT_TEAM = PK2NRTCS5P;
-
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Record/Info.plist;
@@ -425,6 +422,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Record/SnapCarouselView.swift
+++ b/Record/SnapCarouselView.swift
@@ -163,7 +163,6 @@ struct SnapCarousel: View {
                                 .padding(.bottom, 120)
                                 .padding(.leading, 4)
                             } // Z스택
-<<<<<<< HEAD
                         }
                     } // V스택
                     .ignoresSafeArea()

--- a/Record/WriteView.swift
+++ b/Record/WriteView.swift
@@ -85,7 +85,9 @@ struct WriteView: View {
                             
                         }
                         .onTapGesture {
-                            showingImagePicker = true
+                                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to:nil, from:nil, for:nil)
+                            
+                                showingImagePicker = true
                         }
                         .offset(y: -110)
                         .zIndex(1)
@@ -209,7 +211,10 @@ struct WriteView: View {
                     } // if-else End
                 }
             } // tool bar End
-        }.ignoresSafeArea(.keyboard, edges: .bottom)
+        }.onTapGesture {                         // keyboard dismiss
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to:nil, from:nil, for:nil)
+        }
+        .ignoresSafeArea(.keyboard, edges: .bottom)
             .onAppear {
                 if item == nil {
                     item = Content(context: viewContext)


### PR DESCRIPTION
## Keychanges
- WriteView에서 이미지를 클릭시 키보드가 사라지게 수정
- 다크 모드 시 글씨가 흰색으로 되어 안보이는 현상으로 라이트모드만 지원되게 수정.


## Screenshots
|iPhone13, WriteView|
|---|
|![Simulator Screen Recording - iPhone 14 - 2022-09-19 at 00 13 55](https://user-images.githubusercontent.com/66102708/190914360-00d2548a-c995-42d3-a771-5a620fe42ba6.gif)|

## To Reviewer
현재 SwiftUI에서 키보드를 없애는 코드가 없어 send 형식으로 구현하였습니다.

