### PR TITLE
[Fix]: #46 iOS Tool bar 에러 수정

### DIFF
--- a/Record/RecordDetailView.swift
+++ b/Record/RecordDetailView.swift
@@ -152,7 +152,7 @@ struct RecordDetailView: View {
         .fullScreenCover(isPresented: $clickEdit) {
             NavigationView {
                 WriteView(music: Music(artist: item.artist!, title: item.title!, albumArt: item.albumArt!), isEdit: .constant(true), item: item)
-                    .padding(.top, -40)
+                    .navigationBarTitleDisplayMode(.inline)
             }
         }
         .alert("삭제", isPresented: $deleteItemAlert) {
@@ -167,10 +167,6 @@ struct RecordDetailView: View {
                 }
             } message: {  }
         // 본문 ZStack End
-        
-            
-        
-        
     }
     
 }


### PR DESCRIPTION
## Keychanges
- RecordDetialView - 편집 WriteView에서 콘텐츠와 툴바의 영역이 겹치는 문제 해결
- 기존에 -40으로 준 padding값을 navigationbarStyle을 변경하여 해결


## Screenshots
|iPhone14, iOS16 |iPhone13, iOS15.5 |iPhoneSE, iOS15.5|
|---|---|---|
|<img src = "https://user-images.githubusercontent.com/41153398/192132637-309bf5e3-f315-418e-bc53-b9113ea479e0.png" width = 250> |<img src = "https://user-images.githubusercontent.com/41153398/192132584-b4be8b31-2eee-49f9-b103-bf094ea8eec2.png" width = 250> | <img src = "https://user-images.githubusercontent.com/41153398/192132601-7464cc58-edfc-46b4-9d0f-253638429b3a.png" width = 250>


## 기존 문제 상황
|iPhone13, iOS16| iPhone13, iOS 15.5|
|---|---|
|<img src = "https://user-images.githubusercontent.com/68676844/192082108-0b95324a-ff8e-4cc3-abc7-eab0331ab602.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/192082162-ae2eb54e-4aaf-429e-b9cb-e82fe8893cd3.png" width = 250>|
