### PR TITLE
기기대응, 메인화면 및 텍스트 크기 지정

### DIFF
--- a/Extension.swift
+++ b/Extension.swift
@@ -33,31 +33,73 @@ extension Font {
     // font(Font.customTitle1()) 이런식으로 사용하시면 돼요!
     
     static func customLargeTitle() -> Font {
-        return Font.system(size: 34, weight: .heavy)
+        return Font.system(size: 34 * setSize(), weight: .heavy)
     }
     static func customTitle1() -> Font {
-        return Font.system(size: 28, weight: .semibold)
+        return Font.system(size: 28 * setSize(), weight: .semibold)
     }
     static func customTitle2() -> Font {
-        return Font.system(size: 24, weight: .bold)
+        return Font.system(size: 24 * setSize(), weight: .bold)
     }
     static func customTitle3() -> Font {
-        return Font.system(size: 20, weight: .regular)
+        return Font.system(size: 20 * setSize(), weight: .regular)
     }
     static func customHeadline() -> Font {
-        return Font.system(size: 17, weight: .bold)
+        return Font.system(size: 17 * setSize(), weight: .bold)
     }
     static func customBody1() -> Font {
-        return Font.system(size: 17, weight: .regular)
+        return Font.system(size: 17 * setSize(), weight: .regular)
     }
     static func customBody2() -> Font {
-        return Font.system(size: 15, weight: .regular)
+        return Font.system(size: 15 * setSize(), weight: .regular)
     }
     static func customSubhead() -> Font {
-        return Font.system(size: 15, weight: .bold)
+        return Font.system(size: 15 * setSize(), weight: .bold)
     }
     static func customFootnote() -> Font {
-        return Font.system(size: 13, weight: .regular)
+        return Font.system(size: 13 * setSize(), weight: .regular)
+    }
+    
+    static func setSize() -> Double {
+        let height = UIScreen.screenHeight
+        var size = 1.0
+        
+        switch height {
+        case 480.0: //Iphone 3,4S => 3.5 inch
+            size = 0.85
+            break
+        case 568.0: //iphone 5, SE => 4 inch
+            size = 0.9
+            break
+        case 667.0: //iphone 6, 6s, 7, 8 => 4.7 inch
+            size = 0.9
+            break
+        case 736.0: //iphone 6s+ 6+, 7+, 8+ => 5.5 inch
+            size = 0.95
+            break
+        case 812.0: //iphone X, XS => 5.8 inch, 13 mini, 12, mini
+            size = 0.98
+            break
+        case 844.0: // iphone 14, iphone 13 pro, iphone 13, 12 pro, 12
+            size = 1
+            break
+        case 852.0: // iphone 14 pro
+            size = 1
+            break
+        case 926.0: // iphone 14 plus, iphone 13 pro max, 12 pro max
+            size = 1.05
+            break
+        case 896.0: //iphone XR => 6.1 inch  // iphone XS MAX => 6.5 inch, 11 pro max, 11
+            size = 1.05
+            break
+        case 932.0: // iPhone14 Pro Max
+            size = 1.08
+            break
+        default:
+            size = 1
+            break
+        }
+        return size
     }
 }
 

--- a/Record/HomeView.swift
+++ b/Record/HomeView.swift
@@ -25,14 +25,15 @@ struct HomeView: View {
                     
                     Image("Logo")
                         .padding(.top, UIScreen.getHeight(47))
-                        .padding(.leading, UIScreen.getWidth(34))
+                        .padding(.leading, UIScreen.getWidth(50))
                     
                     ZStack {
                         VStack {
                             HStack(spacing: 5) {
                                 
                                 // MARK: link to CDListView
-                                VStack(spacing: 0) {
+                                
+                                VStack {
                                     Text("내 음악 보러 가기")
                                         .foregroundColor(.titleDarkgray)
                                         .font(Font.customHeadline())
@@ -40,6 +41,9 @@ struct HomeView: View {
                                     
                                     NavigationLink(destination: CdListView()) {
                                         Image("album")
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: UIScreen.getWidth(130), height: UIScreen.getHeight(134))
                                     }
                                     .navigationBarTitle("홈")
                                     
@@ -50,9 +54,16 @@ struct HomeView: View {
                                 
                                 // MARK: CD Player
                                 ZStack(alignment: .top) {
+                                    
                                     Image("CdPlayer")
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: UIScreen.getWidth(144))
                                     
                                     Image("HomeCD")
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: UIScreen.getWidth(130), height: UIScreen.getWidth(130))
                                         .rotationEffect(.degrees(angle))
                                         .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
                                         .onTapGesture { angle += Double.random(in: 3600 ..< 3960) }
@@ -72,35 +83,53 @@ struct HomeView: View {
                                 .frame(maxWidth: .infinity)
                             
                             Image("polaroid")
-                                .padding(.bottom, UIScreen.getHeight(55))
-
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: UIScreen.getWidth(60), height: UIScreen.getHeight(80))
+                                .padding(.bottom, UIScreen.getHeight(80))
+                            
                             // MARK: Lamp
                             HStack(alignment: .bottom, spacing: 45) {
                                 ZStack(alignment: .top) {
                                     Image("lampTop")
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: UIScreen.getWidth(120), height: UIScreen.getHeight(30))
                                         .blur(radius: isLighting ? 25 : 0)
                                         .animation(.spring(), value: isLighting)
                                     
                                     Image("lamp")
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: UIScreen.getWidth(120), height: UIScreen.getHeight(83))
                                 }
                                 .onTapGesture {
                                     isLighting.toggle()
                                 }
                                 
+                                
                                 // MARK: Link to SearchView
+                                
                                 VStack(spacing: 0) {
                                     Text("음악 기록하기")
                                         .foregroundColor(.titleDarkgray)
                                         .font(Font.customHeadline())
+                                        .padding()
                                     
-                                    NavigationLink(destination: SearchView()) {
-                                        Image("note")
+                                    VStack(spacing: 0) {
+                                        NavigationLink(destination: SearchView()) {
+                                            Image("note")
+                                                .resizable()
+                                                .scaledToFill()
+                                                .frame(width: UIScreen.getWidth(170), height: UIScreen.getHeight(156))
+                                        }
                                     }
+                                    
                                 }
                             }
                             
                             Image("desk")
-                                .padding(.leading, UIScreen.getWidth(40))
+                                .padding(.leading)
                         }
                         
                     }


### PR DESCRIPTION
## Keychanges
- 기기 별 텍스트 크기의 비율을 조절하였습니다.
  - 기기에서 크기가 적절한지 확인 후 수정이 필요합니다.
- 메인 화면의 이미지 크기를 조절하였습니다.


## Screenshots
|iPhone13, iOS 16|iPhoneSE, iOS 16|iPhone 14 Pro Max, iOS 16|
|---|---|---|
|<img src = "https://user-images.githubusercontent.com/68676844/192517296-74bcbfa4-79c3-412e-b45d-aa583a9b5b2c.png" width = 250> |<img src = "https://user-images.githubusercontent.com/68676844/192517212-c176c989-08cd-49f0-af29-902c04dc7f89.png" width = 250> | <img src = "https://user-images.githubusercontent.com/68676844/192517228-849f29a1-d177-4b9e-a90b-3000eaea774f.png" width = 250>



