### PR TITLE
SnapCarouselVIew - 노래 제목 및 가수 텍스트 프레임 지정

### DIFF
--- a/Record/SnapCarouselView.swift
+++ b/Record/SnapCarouselView.swift
@@ -41,10 +41,14 @@ struct SnapCarousel: View {
                                                 .foregroundColor(Color.titleBlack)
                                                 .font(Font.customTitle3())
                                                 .padding(.bottom, 2)
+                                                .frame(minWidth: UIScreen.getWidth(320))
+                                            
                                             Text(items[content].artist!)
                                                 .foregroundColor(Color.titleDarkgray)
                                                 .font(Font.customBody2())
                                                 .padding(.bottom, UIScreen.getHeight(20))
+                                                .frame(minWidth: UIScreen.getWidth(320))
+                                            
                                         } else {
                                             Spacer()
                                                 .frame(height: 70)
@@ -130,7 +134,6 @@ struct SnapCarousel: View {
                                     .padding(.leading, 4)
                                 }
                             }
-                        .ignoresSafeArea()
                     }
                     .onAppear {
                         items = PersistenceController.shared.fetchContent()

--- a/Record/SnapCarouselView.swift
+++ b/Record/SnapCarouselView.swift
@@ -41,13 +41,13 @@ struct SnapCarousel: View {
                                                 .foregroundColor(Color.titleBlack)
                                                 .font(Font.customTitle3())
                                                 .padding(.bottom, 2)
-                                                .frame(minWidth: UIScreen.getWidth(320))
+                                                .frame(minWidth: UIScreen.getWidth(340))
                                             
                                             Text(items[content].artist!)
                                                 .foregroundColor(Color.titleDarkgray)
                                                 .font(Font.customBody2())
                                                 .padding(.bottom, UIScreen.getHeight(20))
-                                                .frame(minWidth: UIScreen.getWidth(320))
+                                                .frame(minWidth: UIScreen.getWidth(340))
                                             
                                         } else {
                                             Spacer()


### PR DESCRIPTION
## Keychanges
- 노래 제목이 길 때, cd 사이즈가 크게 주는 이슈를 해결하였습니다.

## Screenshots
| before, 여러줄 제목|after, 여러 줄 제목|한 줄 제목|
|---|---|---|
|<img src = "https://user-images.githubusercontent.com/68676844/174327827-712ab771-aead-4922-83a4-be2ab5f7811b.png" width = 250>| <img src = "https://user-images.githubusercontent.com/68676844/192842953-e757dfd3-4566-4506-ae63-5516078c8b01.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/192841769-1823195f-4c0a-4081-8267-76f396b39f0d.png" width = 250>


## To Reviewer
- Marquee (텍스트가 흘러가는 것)으로 해결하고자 하였으나, 몇 이슈가 존재하여 우선 텍스트 프레임을 조절하는 방식으로 지정했습니다.
- 해당 이슈는 discussions 탭에 올려두도록 하겠습니다!
