### PR TITLE
Fix # 74 기록 저장시 앱 종료 버그 수정

### DIFF
--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -159,7 +159,7 @@ struct RecordDetailView: View {
         }))// Menu 목록 End
         .fullScreenCover(isPresented: $clickEdit) {
             NavigationView {
-                WriteView(music: Music(artist: item.artist!, title: item.title!, albumArt: item.albumArt!), isEdit: .constant(true), item: item)
+                WriteView(music: Music(artist: item.artist!, title: item.title!, albumArt: item.albumArt!), isWrite: .constant(false) ,isEdit: .constant(true), item: item)
                     .navigationBarTitleDisplayMode(.inline)
             }
         }

--- a/Record/Views/WriteViews/SearchView.swift
+++ b/Record/Views/WriteViews/SearchView.swift
@@ -136,7 +136,7 @@ struct SearchView: View {
                             .frame(width: 55, height: 55)
                         
                         // 글 작성 페이지로 전환
-                        NavigationLink(destination: WriteView(music: music, isEdit: .constant(false), item: nil)) {
+                        NavigationLink(destination: WriteView(music: music, isWrite: .constant(true) ,isEdit: .constant(true), item: nil)) {
                             
                             // 제목, 가수 출력
                             VStack(alignment: .leading) {

--- a/Record/Views/WriteViews/WriteView.swift
+++ b/Record/Views/WriteViews/WriteView.swift
@@ -29,6 +29,7 @@ struct WriteView: View {
     @State private var lyrics = ""
     @State private var content = ""
     
+    @Binding var isWrite: Bool
     @Binding var isEdit: Bool
     @State var item: Content?
     @State var index: Int = -1
@@ -77,7 +78,7 @@ struct WriteView: View {
                                     .foregroundColor(.titleDarkgray)
                                 
                             }
-//                            .padding(.vertical, UIScreen.getHeight(15))
+                            //                            .padding(.vertical, UIScreen.getHeight(15))
                             
                             // MARK: CD Player
                             HStack {
@@ -165,15 +166,28 @@ struct WriteView: View {
                 .frame(maxHeight: .infinity, alignment: .topLeading)
                 
             }
-            
+            .navigationBarBackButtonHidden(true)
             // 저장 버튼 누르면 Alert 창이 나오고, 홈으로 이동
             .toolbar {
                 
                 ToolbarItem(placement: .navigationBarLeading) {
                     if isEdit {
-                        Button("닫기", action: {
-                            presentationMode.wrappedValue.dismiss()
-                        })
+                        if isWrite {
+                            Button {
+                                PersistenceController.shared.deleteContent(item: item ?? Content())
+                                presentationMode.wrappedValue.dismiss()
+                            } label: {
+                                HStack {
+                                    Image(systemName: "chevron.backward")
+                                        .font(Font.headline.weight(.semibold))
+                                    Text("음악 선택")
+                                }
+                            }
+                        } else {
+                            Button("닫기", action: {
+                                presentationMode.wrappedValue.dismiss()
+                            })
+                        }
                     }
                 }
                 
@@ -199,7 +213,7 @@ struct WriteView: View {
                             Alert(
                                 title: Text("저장 완료"),
                                 dismissButton: .default(Text("확인")) {
-                                    if isEdit {
+                                    if isEdit && !isWrite {
                                         presentationMode.wrappedValue.dismiss()
                                     } else {
                                         NavigationUtil.popToRootView()
@@ -269,6 +283,6 @@ struct NavigationUtil {
 
 struct WriteView_Previews: PreviewProvider {
     static var previews: some View {
-        WriteView(music: Music(artist: "가수이름", title: "노래제목", albumArt: "https://is3-ssl.mzstatic.com/image/thumb/Music122/v4/f7/68/9c/f7689ce3-6d41-60cd-62d2-57a91ddf5b9d/196922067341_Cover.jpg/100x100bb.jpg"), isEdit: .constant(false))
+        WriteView(music: Music(artist: "가수이름", title: "노래제목", albumArt: "https://is3-ssl.mzstatic.com/image/thumb/Music122/v4/f7/68/9c/f7689ce3-6d41-60cd-62d2-57a91ddf5b9d/196922067341_Cover.jpg/100x100bb.jpg"), isWrite: .constant(true), isEdit: .constant(false))
     }
 }


### PR DESCRIPTION
## Keychanges
- 음악을 검색한 후 기록 작성 뷰에서 검색뷰로 이전하여 다시 작성해서 저장할 경우 앱이 종료되는 버그를 수정하였습니다.


## Screenshots
|iPhone13, WriteView|
|---|
![Simulator Screen Recording - iPhone 14 - 2022-11-08 at 16 03 47](https://user-images.githubusercontent.com/66102708/200496863-53c2720f-13d5-4f76-b2f6-c60d3586ad57.gif)
|<img src = "" width = 250> 


## To Reviewer
기록을 저장하는 Core Data가 한 번 검색한 Content를 이전으로 돌아가도 계속 observe 하는 것 같아서 이전으로 돌아갈 시
현재 검색한 Content를 삭제하였습니다.


