### PR TITLE
[Feat] #75 검색 결과 초기화

### DIFF
--- a/Record/Views/CDListView/CdListView.swift
+++ b/Record/Views/CDListView/CdListView.swift
@@ -31,7 +31,7 @@ struct CdListView: View {
                                 .padding(.bottom, UIScreen.getHeight(12))
                                 .padding(.top, UIScreen.getHeight(260))
                             
-                            NavigationLink(destination: SearchView()) {
+                            NavigationLink(destination: SearchView(isAccessFirst: true)) {
                                 Text("음악 기록하러 가기")
                             }//.isDetailLink(false)
                                 //go to WriteView

--- a/Record/Views/HomeView.swift
+++ b/Record/Views/HomeView.swift
@@ -117,7 +117,7 @@ struct HomeView: View {
                                         .padding()
                                     
                                     VStack(spacing: 0) {
-                                        NavigationLink(destination: SearchView()) {
+                                        NavigationLink(destination: SearchView(isAccessFirst: true)) {
                                             Image("note")
                                                 .resizable()
                                                 .scaledToFill()

--- a/Record/Views/WriteViews/SearchView.swift
+++ b/Record/Views/WriteViews/SearchView.swift
@@ -17,8 +17,9 @@ struct SearchView: View {
     @State var progress: Bool
     private let placeholer = "기록하고 싶은 음악, 가수를 입력하세요"
     @FocusState private var isSearchbarFocused: Bool?
+    @State var isAcessFirst: Bool
     
-    init() {
+    init(isAccessFirst: Bool) {
         // 검색 결과 출력 리스트 배경색 초기화
         UITableView.appearance().backgroundColor = UIColor.clear
         
@@ -26,6 +27,7 @@ struct SearchView: View {
         let state = State(initialValue: false)
         self._progress = state
         self.musicAPI = MusicAPI(progress: state.projectedValue)
+        self.isAcessFirst = isAccessFirst
     }
     
     var body: some View {
@@ -162,6 +164,12 @@ struct SearchView: View {
                 
             } // List End
             .listStyle(.plain)
+            .onAppear() {
+                if isAcessFirst {
+                    self.musicAPI.musicList = []
+                    isAcessFirst = false
+                }
+            }
             
         } // GeometryReder End
         
@@ -212,6 +220,6 @@ struct URLImage: View {
 // MARK: - 현재 뷰 프리뷰
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchView()
+        SearchView(isAccessFirst: true)
     }
 }


### PR DESCRIPTION
## Keychanges
- SearchView에서 검색 > HomeView >  SearchView로 접근 시 화면에 남아있는 검색 결과 리스트를 초기화하는 기능을 추가했습니다.


## Screenshots
https://user-images.githubusercontent.com/41153398/200591951-8af7749a-d51c-43a6-8be9-b4621ad3c800.mp4


## To Reviewer
- Bool값을 하나 추가하여 다른 화면에서 navigationlink로 접근하는 경우와 뒤로가기로 접근하는 경우를 구분해서 결과 리스트를 초기화하도록 했습니다. 