### PR TITLE
[Fix] #71 - 저장되는 이미지를 png에서 jpeg로 변경

### DIFF
--- a/Record/Views/WriteViews/WriteView.swift
+++ b/Record/Views/WriteViews/WriteView.swift
@@ -202,7 +202,7 @@ struct WriteView: View {
                         Button("저장") {
                             
                             item!.story = content
-                            item!.image = inputImage!.pngData()
+                            item!.image = inputImage!.jpegData(compressionQuality: 1)
                             item!.lyrics = lyrics
                             
                             PersistenceController.shared.saveContent()


### PR DESCRIPTION
## Keychanges
- 4:3 비율의 사진이 저장되면 이미지가 회전하는 이슈가 있었음
- png로 저장되던 이미지를 jpeg로 변경하니 이미지가 회전하지 않음

## Screenshots
![IMB_Ds5yuc](https://user-images.githubusercontent.com/98628614/203115572-7031b517-101b-4fc0-9937-4c36747909c6.GIF)
