### PR TITLE
[Feat] 수정 후 리스트 업데이트 안 되는 문제 해결

### DIFF
--- a/Record.xcodeproj/project.pbxproj
+++ b/Record.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		87E96F4928DF93C4007D167E /* FirstPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E96F4828DF93C4007D167E /* FirstPage.swift */; };
 		87E96F4B28DF93CC007D167E /* SecondPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E96F4A28DF93CC007D167E /* SecondPage.swift */; };
 		87E96F4D28DF940A007D167E /* ThirdPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E96F4C28DF940A007D167E /* ThirdPage.swift */; };
+		87F1956D295FED74004A1CAF /* URLImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F1956C295FED74004A1CAF /* URLImage.swift */; };
 		87FB281D285A04680036A5BB /* Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FB281C285A04680036A5BB /* Screenshot.swift */; };
 		A01413222855F4E60000EA59 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01413212855F4E60000EA59 /* HomeView.swift */; };
 		A0AA39BB285A4936009EE3EA /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AA39BA285A4936009EE3EA /* OnboardingView.swift */; };
@@ -63,6 +64,7 @@
 		87E96F4828DF93C4007D167E /* FirstPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstPage.swift; sourceTree = "<group>"; };
 		87E96F4A28DF93CC007D167E /* SecondPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondPage.swift; sourceTree = "<group>"; };
 		87E96F4C28DF940A007D167E /* ThirdPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPage.swift; sourceTree = "<group>"; };
+		87F1956C295FED74004A1CAF /* URLImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLImage.swift; sourceTree = "<group>"; };
 		87FB281C285A04680036A5BB /* Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screenshot.swift; sourceTree = "<group>"; };
 		A01413212855F4E60000EA59 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		A0AA39BA285A4936009EE3EA /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				87B6E3D728EC9BB8002D579A /* WriteViews */,
 				87B6E3D828EC9BFC002D579A /* DetailViews */,
 				87B6E3D928EC9C27002D579A /* CDListView */,
+				87F1956B295FED24004A1CAF /* Components */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -206,6 +209,14 @@
 				87E96F4C28DF940A007D167E /* ThirdPage.swift */,
 			);
 			path = OnboardingViews;
+			sourceTree = "<group>";
+		};
+		87F1956B295FED24004A1CAF /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				87F1956C295FED74004A1CAF /* URLImage.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -290,6 +301,7 @@
 				B29723B0285B192C0065FD36 /* SnapCarouselView.swift in Sources */,
 				87E96F4D28DF940A007D167E /* ThirdPage.swift in Sources */,
 				87FB281D285A04680036A5BB /* Screenshot.swift in Sources */,
+				87F1956D295FED74004A1CAF /* URLImage.swift in Sources */,
 				8715A79B2855479E001AB4F5 /* MusicAPI.swift in Sources */,
 				87B6E3CD28EC9764002D579A /* Color+Extensions.swift in Sources */,
 				87A0D9B4285BAF42006D0D3B /* Record.xcdatamodeld in Sources */,

--- a/Record/Views/Components/URLImage.swift
+++ b/Record/Views/Components/URLImage.swift
@@ -1,0 +1,36 @@
+//
+//  URLImage.swift
+//  Record
+//
+//  Created by 이지원 on 2022/12/31.
+//
+
+import SwiftUI
+
+/// url string 을 이용해서 image를 불러옵니다.
+/// - parameters
+/// urlString: 이미지의 url 을 입력해주세요
+
+struct URLImage: View {
+    
+    let urlString: String
+
+    var body: some View {
+
+        AsyncImage(url: URL(string: urlString)) { image in
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .background(.gray)
+
+        } placeholder: {
+            Color.titleLightgray
+        }
+    }
+}
+
+struct URLImage_Previews: PreviewProvider {
+    static var previews: some View {
+        URLImage(urlString: "https://cdn.pixabay.com/photo/2022/01/11/21/48/link-6931554_1280.png")
+    }
+}

--- a/Record/Views/WriteViews/SearchView.swift
+++ b/Record/Views/WriteViews/SearchView.swift
@@ -182,37 +182,21 @@ struct SearchView: View {
 // MARK: - 앨범 커버 불러오기
 struct URLImage: View {
     
-    @State var data: Data?
-    let urlString: String
+    var urlString: String
     
     var body: some View {
         
-        // 앨범 커버 불러오기
-        if let data = data, let uiimage = UIImage(data: data) { // 이미지 불러오기 성공
-            
-            Image(uiImage: uiimage) // URL Image
+        AsyncImage(url: URL(string: urlString)) { image in
+            image
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .background(.gray)
             
-        } else { // 이미지 불러오기 실패
-            
-            Rectangle() // 회색 박스
+        } placeholder: {
+            Rectangle()
                 .foregroundColor(.titleLightgray)
                 .aspectRatio(contentMode: .fit)
-                .onAppear() {
-                    fetchData()
-                }
         }
-    }
-    
-    private func fetchData() {
-        guard let url = URL(string: urlString) else { return }
-        
-        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
-            self.data = data
-        }
-        task.resume()
     }
 }
 

--- a/Record/Views/WriteViews/SearchView.swift
+++ b/Record/Views/WriteViews/SearchView.swift
@@ -178,29 +178,6 @@ struct SearchView: View {
 } //SearchView struct End
 
 
-
-// MARK: - 앨범 커버 불러오기
-struct URLImage: View {
-    
-    var urlString: String
-    
-    var body: some View {
-        
-        AsyncImage(url: URL(string: urlString)) { image in
-            image
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .background(.gray)
-            
-        } placeholder: {
-            Rectangle()
-                .foregroundColor(.titleLightgray)
-                .aspectRatio(contentMode: .fit)
-        }
-    }
-}
-
-
 // MARK: - 현재 뷰 프리뷰
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
## Keychanges
- 음악 삭제 후, 이미지가 새로고침되도록 변경하였습니다.
- closes #77


## Screenshots
https://user-images.githubusercontent.com/68676844/210124076-ab1b78a5-6d8d-40ba-be29-21bc19deb488.mov

## To Reviewer
### 문제가 생긴 이유
- 변경된 URL 이미지가 호출하지 않아서! (coredata 문제인 줄 알았는데 아니더라구요)
- 텍스트는 제대로 업데이트 되는데, 사진만 업데이트 되지 않는게 이상해서 삽질 삽질 삽질..
- URL Image가 SwiftUI에서 제공하는건 줄 알았어요... 확인해보지 않은 제 불찰입니다.
  - 헷갈릴 가능성이 있어서 components라는 폴더 만들어서 구조화시켰씁니다.(추후 여러 뷰에서 사용되는 컴포넌트들 관리하면 좋을 것 같아요)
- 삽질하면서 코어데이터 리팩토링했는데, 지금 문제가 있어서 따로 커밋하지 않았어요. 새로 이슈 끊어서 작업하겠습니다~
  - 문제: 편집 후 Alert가 자기 멋대로 닫힘 + 편집 화면에서 나가지지 않음 (예전에 있었던 이슈 같은데, 혹시 해결 방법 아시는 분 공유부탁드려요 따로 기록이 없네요ㅜㅜ)

### AsyncImage란?
- URLSession 인스턴스로 이미지 가져올 수 있는 기능입니다 (iOS 15부터 사용 가능)
- placeholder는 이미지 불러오기 전에 보여지는 화면이에요!

