### PR TITLE
[Feat] 패딩 값 수정

### DIFF
--- a/Record/Views/HomeView.swift
+++ b/Record/Views/HomeView.swift
@@ -33,17 +33,18 @@ struct HomeView: View {
                                 
                                 // MARK: link to CDListView
                                 
-                                VStack {
+                                VStack(spacing: 0) {
                                     Text("내 음악 보러 가기")
                                         .foregroundColor(.titleDarkgray)
                                         .font(Font.customHeadline())
-                                        .padding(.top, UIScreen.getHeight(50))
+                                        .padding(.top, UIScreen.getHeight(90))
+                                        .padding(.bottom, UIScreen.getHeight(6))
                                     
                                     NavigationLink(destination: CdListView()) {
                                         Image("album")
                                             .resizable()
-                                            .scaledToFill()
-                                            .frame(width: UIScreen.getWidth(130), height: UIScreen.getHeight(134))
+                                            .scaledToFit()
+                                            .frame(width: UIScreen.getWidth(130))
                                     }
                                     .navigationBarTitle("홈")
                                     
@@ -114,14 +115,14 @@ struct HomeView: View {
                                     Text("음악 기록하기")
                                         .foregroundColor(.titleDarkgray)
                                         .font(Font.customHeadline())
-                                        .padding()
+                                        .padding(.bottom, UIScreen.getHeight(6))
                                     
                                     VStack(spacing: 0) {
                                         NavigationLink(destination: SearchView(isAccessFirst: true)) {
                                             Image("note")
                                                 .resizable()
-                                                .scaledToFill()
-                                                .frame(width: UIScreen.getWidth(170), height: UIScreen.getHeight(156))
+                                                .scaledToFit()
+                                                .frame(width: UIScreen.getWidth(170))
                                         }
                                     }
                                     


### PR DESCRIPTION
## Keychanges
- Home View의 컴포넌트 위치가 기존 HiFi design과 다른 이슈를 해결하였습니다.
- close #72

## Screenshots
|iPhone13|iPhoneSE|iPhone14ProMax|
|---|---|---|
|<img src = "https://user-images.githubusercontent.com/68676844/216038380-a982c7f5-610e-4017-9daa-f4ad0bac9632.png" width = 250> | <img src = "https://user-images.githubusercontent.com/68676844/216038374-ac9d3745-b058-4742-9755-8bbc6fed88d3.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/216037995-e2ce5624-13ef-483d-a286-c631b7a7ec63.png" width = 250>

## To Reviewer
- 이미지의 width, height 을 모두 지정하고, scale to Fill 을 수행하게 되면 컴포넌트 사이 중첩이 발생합니다. (글자가 이미지에 가려지는 이슈가 발생해요) 정해진 크기보다 더 큰 영역을 차지하기 때문입니다!
- 이에 이미지의 width만 지정하고, scale to fit으로 설정하여 이슈를 해결하였습니다.
