### PR TITLE
[Fix] #90 - 이미지 선택 후 애니메이션이 동작하지 않는 버그 수정

### DIFF
--- a/Record/Views/DetailViews/PhotoModalView.swift
+++ b/Record/Views/DetailViews/PhotoModalView.swift
@@ -59,6 +59,9 @@ struct PhotoModalView: View {
                 }
             } // 본문 Frame & Photo 끝
         }
+        .onDisappear {
+            UIView.setAnimationsEnabled(true)
+        }
     }
 }
 //

--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -31,7 +31,7 @@ struct RecordDetailView: View {
             }
         }
     }
-
+    
     var body: some View {
         
         ZStack {
@@ -270,7 +270,7 @@ class MyActivityItemSource: NSObject, UIActivityItemSource {
     func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
         return title
     }
-
+    
     func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
         let metadata = LPLinkMetadata()
         metadata.title = title

--- a/Record/Views/DetailViews/StoryModalView.swift
+++ b/Record/Views/DetailViews/StoryModalView.swift
@@ -57,6 +57,9 @@ struct StoryModalView: View {
                 }
             } // 본문 Frame & Text 끝
         }
+        .onDisappear {
+            UIView.setAnimationsEnabled(true)
+        }
     }
 }
 

--- a/Record/Views/WriteViews/WritingModalView.swift
+++ b/Record/Views/WriteViews/WritingModalView.swift
@@ -107,7 +107,10 @@ struct WritingModalView: View {
                 .background(Color.white)
             } // Modal Background Frame & Color 끝
             
-            
+
+        }
+        .onDisappear {
+            UIView.setAnimationsEnabled(true)
         }
     }
 }


### PR DESCRIPTION
## Keychanges
- 이미지, 짧은 이야기를 선택한 후 애니메이션이 동작하지 않는 버그를 수정하였습니다.


## Screenshots
|iPhone13, 화면이름|
|---|
|<img src = "https://user-images.githubusercontent.com/66102708/219934515-a6f67983-24d8-4129-98de-bae4a50fa795.gif" width = 250> |


## To Reviewer
이미지와 이야기 뷰로 들어갈 때 [애니메이션을 false값을 주면서 생긴 버그](https://github.com/DeveloperAcademy-POSTECH/MC2-Team7-Larasy/blob/7fb86261271b3b06da63152692b3c86e3f6d353e/Record/Views/DetailViews/RecordDetailView.swift#L122)
👉이미지와 이야기뷰가 닫힐 때 애니메이션이 실행될 수 있도록 값을 주었습니다.
