### PR TITLE
[Feat] #92 - marquee textView  적용

### DIFF
--- a/Record.xcodeproj/project.pbxproj
+++ b/Record.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		B277EC152859A671001A97B1 /* Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B277EC142859A671001A97B1 /* Carousel.swift */; };
 		B277EC172859A679001A97B1 /* CdListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B277EC162859A679001A97B1 /* CdListView.swift */; };
 		B29723B0285B192C0065FD36 /* SnapCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29723AF285B192C0065FD36 /* SnapCarouselView.swift */; };
+		F9BA11F329A499D500176807 /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BA11F229A499D500176807 /* MarqueeTextView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +73,7 @@
 		B277EC142859A671001A97B1 /* Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Carousel.swift; sourceTree = "<group>"; };
 		B277EC162859A679001A97B1 /* CdListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CdListView.swift; sourceTree = "<group>"; };
 		B29723AF285B192C0065FD36 /* SnapCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapCarouselView.swift; sourceTree = "<group>"; };
+		F9BA11F229A499D500176807 /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,6 +173,7 @@
 				B277EC162859A679001A97B1 /* CdListView.swift */,
 				B29723AF285B192C0065FD36 /* SnapCarouselView.swift */,
 				B277EC142859A671001A97B1 /* Carousel.swift */,
+				F9BA11F229A499D500176807 /* MarqueeTextView.swift */,
 			);
 			path = CDListView;
 			sourceTree = "<group>";
@@ -291,6 +294,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F9BA11F329A499D500176807 /* MarqueeTextView.swift in Sources */,
 				B277EC172859A679001A97B1 /* CdListView.swift in Sources */,
 				87E96F4928DF93C4007D167E /* FirstPage.swift in Sources */,
 				87E96F4B28DF93CC007D167E /* SecondPage.swift in Sources */,

--- a/Record/Extensions/Font+Extensions.swift
+++ b/Record/Extensions/Font+Extensions.swift
@@ -81,3 +81,51 @@ extension Font {
         return size
     }
 }
+
+extension UIFont {
+    static func customTitle3() -> UIFont {
+        return .systemFont(ofSize: 20 * setSize(), weight: .regular)
+    }
+    
+    static func setSize() -> Double {
+        let height = UIScreen.screenHeight
+        var size = 1.0
+        
+        switch height {
+        case 480.0: //Iphone 3,4S => 3.5 inch
+            size = 0.85
+            break
+        case 568.0: //iphone 5, SE => 4 inch
+            size = 0.9
+            break
+        case 667.0: //iphone 6, 6s, 7, 8 => 4.7 inch
+            size = 0.9
+            break
+        case 736.0: //iphone 6s+ 6+, 7+, 8+ => 5.5 inch
+            size = 0.95
+            break
+        case 812.0: //iphone X, XS => 5.8 inch, 13 mini, 12, mini
+            size = 0.98
+            break
+        case 844.0: // iphone 14, iphone 13 pro, iphone 13, 12 pro, 12
+            size = 1
+            break
+        case 852.0: // iphone 14 pro
+            size = 1
+            break
+        case 926.0: // iphone 14 plus, iphone 13 pro max, 12 pro max
+            size = 1.05
+            break
+        case 896.0: //iphone XR => 6.1 inch  // iphone XS MAX => 6.5 inch, 11 pro max, 11
+            size = 1.05
+            break
+        case 932.0: // iPhone14 Pro Max
+            size = 1.08
+            break
+        default:
+            size = 1
+            break
+        }
+        return size
+    }
+}

--- a/Record/Views/CDListView/MarqueeTextView.swift
+++ b/Record/Views/CDListView/MarqueeTextView.swift
@@ -22,7 +22,7 @@ struct MarqueeTextView: View {
     
     var body: some View {
         
-        if text.textSize(font: font).width < UIScreen.getWidth(340) {
+        if textSize().width < UIScreen.getWidth(340) {
             Text(text)
                 .font(Font(font))
         } else {

--- a/Record/Views/CDListView/MarqueeTextView.swift
+++ b/Record/Views/CDListView/MarqueeTextView.swift
@@ -1,0 +1,79 @@
+//
+//  MarqueeTextView.swift
+//  Record
+//
+//  Created by 전지민 on 2023/02/21.
+//
+
+import SwiftUI
+
+struct MarqueeTextView: View {
+    
+    @State var text: String
+    var font: UIFont
+    
+    @State var storedSize: CGSize = .zero
+    @State var offset: CGFloat = 0
+    
+    var animationSpeed = 0.02
+    var delayTime = 0.5
+    
+    @Environment(\.colorScheme) var scheme
+    
+    var body: some View {
+        
+        if text.textSize(font: font).width < UIScreen.getWidth(340) {
+            Text(text)
+                .font(Font(font))
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(text)
+                    .font(Font(font))
+                    .offset(x: offset)
+                    .padding(.horizontal, 15)
+            }
+            .overlay(content: {
+                HStack {
+                    let color = Color.background
+                    
+                    LinearGradient(colors: [color, color.opacity(0.7), color.opacity(0.5), color.opacity(0.3)], startPoint: .leading, endPoint: .trailing)
+                        .frame(width: 20)
+                    
+                    Spacer()
+                    
+                    LinearGradient(colors: [color, color.opacity(0.7), color.opacity(0.5), color.opacity(0.3)].reversed(), startPoint: .leading, endPoint: .trailing)
+                        .frame(width: 20)
+                }
+            })
+            .disabled(true)
+            .onAppear() {
+                
+                let baseText = text
+                
+                (1...15).forEach { _ in
+                    text.append(" ")
+                }
+                storedSize = textSize()
+                text.append(baseText)
+                
+                let timing = animationSpeed * storedSize.width
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    withAnimation(.linear(duration: timing)) {
+                        offset = -storedSize.width
+                    }
+                }
+            }
+            .onReceive(Timer.publish(every: ((animationSpeed * storedSize.width) + delayTime), on: .main, in: .default).autoconnect()) { _ in
+                offset = 0
+                withAnimation(.linear(duration: animationSpeed * storedSize.width)) {
+                    offset = -storedSize.width
+                }
+            }
+        }
+    }
+    func textSize() -> CGSize {
+        let attributes = [NSAttributedString.Key.font: font]
+        let size = (text as NSString).size(withAttributes: attributes)
+        return size
+    }
+}

--- a/Record/Views/CDListView/MarqueeTextView.swift
+++ b/Record/Views/CDListView/MarqueeTextView.swift
@@ -50,9 +50,7 @@ struct MarqueeTextView: View {
                 
                 let baseText = text
                 
-                (1...15).forEach { _ in
-                    text.append(" ")
-                }
+                text += String(repeating: " ", count: 15)
                 storedSize = textSize()
                 text.append(baseText)
                 

--- a/Record/Views/CDListView/MarqueeTextView.swift
+++ b/Record/Views/CDListView/MarqueeTextView.swift
@@ -34,14 +34,15 @@ struct MarqueeTextView: View {
             }
             .overlay(content: {
                 HStack {
-                    let color = Color.background
+                    let colors = [Color](repeating: Color.background, count: 4)
+                    let gradientColor = zip(colors, [1, 0.7, 0.5, 0.3]).map { $0.0.opacity($0.1) }
                     
-                    LinearGradient(colors: [color, color.opacity(0.7), color.opacity(0.5), color.opacity(0.3)], startPoint: .leading, endPoint: .trailing)
+                    LinearGradient(colors: gradientColor, startPoint: .leading, endPoint: .trailing)
                         .frame(width: 20)
                     
                     Spacer()
                     
-                    LinearGradient(colors: [color, color.opacity(0.7), color.opacity(0.5), color.opacity(0.3)].reversed(), startPoint: .leading, endPoint: .trailing)
+                    LinearGradient(colors: gradientColor.reversed(), startPoint: .leading, endPoint: .trailing)
                         .frame(width: 20)
                 }
             })

--- a/Record/Views/CDListView/SnapCarouselView.swift
+++ b/Record/Views/CDListView/SnapCarouselView.swift
@@ -37,9 +37,8 @@ struct SnapCarousel: View {
                                     // 가운데 cd만 글이 보이게 함
                                     VStack {
                                         if content == UIState.activeCard {
-                                            Text(items[content].title!)
+                                            MarqueeTextView(text: items[content].title!, font: UIFont.customTitle3())
                                                 .foregroundColor(Color.titleBlack)
-                                                .font(Font.customTitle3())
                                                 .padding(.bottom, UIScreen.getHeight(2))
                                                 .frame(minWidth: UIScreen.getWidth(340))
                                             
@@ -48,6 +47,7 @@ struct SnapCarousel: View {
                                                 .font(Font.customBody2())
                                                 .padding(.bottom, UIScreen.getHeight(20))
                                                 .frame(minWidth: UIScreen.getWidth(340))
+                                                .lineLimit(1)
                                             
                                         } else {
                                             Spacer()


### PR DESCRIPTION
## Keychanges
- CDListView 에서 음악 제목이 화면넓이보다 길 경우 marquee text view를 적용함


## Screenshots

iPhone13, 화면이름

https://user-images.githubusercontent.com/41153398/220821251-d917d3c8-19c4-44b8-8ea3-5559d9108007.mp4


iPhoneSE, 화면이름

https://user-images.githubusercontent.com/41153398/220821365-9b596a5b-017d-4cf1-8e71-187fffd4f820.mp4


## To Reviewer

- 현재 제목에만 marquee text view가 적용되어있는 상태로 아티스트의 이름이 길어지는 경우에 동일하게 marquee text view가 적용되어야 하는지 의견을 구합니다.
(아래의 동영상은 아티스트 이름에도 marquee text view 적용했을 때의 모습입니다. )

https://user-images.githubusercontent.com/41153398/220821702-70c63639-06ec-42ce-a628-18996a618678.mov

제목과 아티스트가 둘 다 길어질 경우 따로따로 흘러가는 모습이 어색하다고 생각하여 음원 사이트를 조사해본 결과

| YoutubeMusic | melon | 벅스 | VIBE |
|--|--|--|--|
| <img src = "https://user-images.githubusercontent.com/41153398/220823184-3fa2ffd7-9098-407d-af3c-d3aa5c65ee1f.PNG" width = 300> | <img src = "https://user-images.githubusercontent.com/41153398/220823216-d1957acc-587c-421f-81e8-c49dbd9d0fad.PNG" width = 300> | <img src = "https://user-images.githubusercontent.com/41153398/220823126-88a600d2-7e7f-4187-867c-b443cc39339c.jpeg" width=500> | <img src ="https://user-images.githubusercontent.com/41153398/220823231-fced9fc9-88a0-425e-a329-182786e86407.PNG" width=300> | 

| marquee 적용 유무 |YoutubeMusic | melon | 벅스 | VIBE
|--|--|--|--|--|
|제목| O | O | O | O |
|아티스트| X (그냥 자름) | O | X (말줄임표로 자름) | O |

다 다르게 적용되어있는 것을 알 수 있었습니다. 음원사이트에 비해 아티스트 이름이 잘 정리되어 있지 않는 형태가 많기 때문에 (아티스트 명이 더려운 경우가 많기 때문에) 이 부분을 고려하여 의견을 주신다면 반영하도록 하겠습니다.



- 이슈에 DetailView에 적용되어야 한다고 적혀있는데 해당 화면에도 적용하는 것이 맞을까요? 맞다면 이미지로 저장하는 경우 음악 제목과 아티스트 명을 어떻게 화면에 나타낼 것인지 한번 더 논의가 필요합니다. 
(기존 화면에서 marquee text view를 적용하여 이미지를 저장할 경우 아래의 사진처럼 저장됨)
<img src = "https://user-images.githubusercontent.com/41153398/220824422-7828179e-9cde-4be6-8454-81695dfbb79a.png" width=400>

