### PR TITLE
[Feat] floating view로 변경하기

### DIFF
--- a/Record.xcodeproj/project.pbxproj
+++ b/Record.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		8715A798285531AB001AB4F5 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715A797285531AB001AB4F5 /* SearchView.swift */; };
 		8715A79B2855479E001AB4F5 /* MusicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8715A79A2855479E001AB4F5 /* MusicAPI.swift */; };
 		8715A79D2855B5AC001AB4F5 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8715A79C2855B5AC001AB4F5 /* Colors.xcassets */; };
+		87268D0229BD6DA600C0CA29 /* CDPlayerComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87268D0129BD6DA600C0CA29 /* CDPlayerComponent.swift */; };
 		8786B2F129AA547C000B46A1 /* CDPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8786B2F029AA547C000B46A1 /* CDPlayer.swift */; };
 		8786B2F329AA5726000B46A1 /* CDList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8786B2F229AA5726000B46A1 /* CDList.swift */; };
 		8786B2F529AA5CED000B46A1 /* MusicInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8786B2F429AA5CED000B46A1 /* MusicInformation.swift */; };
@@ -39,11 +40,8 @@
 		A01413222855F4E60000EA59 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01413212855F4E60000EA59 /* HomeView.swift */; };
 		A0AA39BB285A4936009EE3EA /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AA39BA285A4936009EE3EA /* OnboardingView.swift */; };
 		A0AA39BF285AF643009EE3EA /* FourthPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AA39BE285AF643009EE3EA /* FourthPage.swift */; };
-		B277EC152859A671001A97B1 /* Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B277EC142859A671001A97B1 /* Carousel.swift */; };
 		B277EC172859A679001A97B1 /* CdListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B277EC162859A679001A97B1 /* CdListView.swift */; };
-		B29723B0285B192C0065FD36 /* SnapCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29723AF285B192C0065FD36 /* SnapCarouselView.swift */; };
 		F9BA11F329A499D500176807 /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BA11F229A499D500176807 /* MarqueeTextView.swift */; };
-
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -61,6 +59,7 @@
 		8715A797285531AB001AB4F5 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		8715A79A2855479E001AB4F5 /* MusicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicAPI.swift; sourceTree = "<group>"; };
 		8715A79C2855B5AC001AB4F5 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		87268D0129BD6DA600C0CA29 /* CDPlayerComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDPlayerComponent.swift; sourceTree = "<group>"; };
 		8786B2F029AA547C000B46A1 /* CDPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDPlayer.swift; sourceTree = "<group>"; };
 		8786B2F229AA5726000B46A1 /* CDList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDList.swift; sourceTree = "<group>"; };
 		8786B2F429AA5CED000B46A1 /* MusicInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicInformation.swift; sourceTree = "<group>"; };
@@ -81,9 +80,7 @@
 		A01413212855F4E60000EA59 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		A0AA39BA285A4936009EE3EA /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		A0AA39BE285AF643009EE3EA /* FourthPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FourthPage.swift; sourceTree = "<group>"; };
-		B277EC142859A671001A97B1 /* Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Carousel.swift; sourceTree = "<group>"; };
 		B277EC162859A679001A97B1 /* CdListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CdListView.swift; sourceTree = "<group>"; };
-		B29723AF285B192C0065FD36 /* SnapCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapCarouselView.swift; sourceTree = "<group>"; };
 		F9BA11F229A499D500176807 /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -174,6 +171,7 @@
 				13C0E4A128573795004ABE1D /* RecordDetailView.swift */,
 				3D49B5AD285A02B50054FDED /* StoryModalView.swift */,
 				3D49B5AF285A41570054FDED /* PhotoModalView.swift */,
+				87268D0129BD6DA600C0CA29 /* CDPlayerComponent.swift */,
 			);
 			path = DetailViews;
 			sourceTree = "<group>";
@@ -181,7 +179,7 @@
 		87B6E3D928EC9C27002D579A /* CDListView */ = {
 			isa = PBXGroup;
 			children = (
-				B277EC162859A679001A97B1 /* CDListView.swift */,
+				B277EC162859A679001A97B1 /* CdListView.swift */,
 				87D686F129A63B9F00E3707F /* EmptyCDListView.swift */,
 				8786B2F429AA5CED000B46A1 /* MusicInformation.swift */,
 				8786B2F229AA5726000B46A1 /* CDList.swift */,
@@ -308,7 +306,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B277EC172859A679001A97B1 /* CDListView.swift in Sources */,
+				B277EC172859A679001A97B1 /* CdListView.swift in Sources */,
 				8786B2F129AA547C000B46A1 /* CDPlayer.swift in Sources */,
 				8786B2F529AA5CED000B46A1 /* MusicInformation.swift in Sources */,
 				F9BA11F329A499D500176807 /* MarqueeTextView.swift in Sources */,
@@ -333,6 +331,7 @@
 				87B6E3D328EC97CE002D579A /* UIScreen+Extensions.swift in Sources */,
 				3D49B5AE285A02B50054FDED /* StoryModalView.swift in Sources */,
 				8715A798285531AB001AB4F5 /* SearchView.swift in Sources */,
+				87268D0229BD6DA600C0CA29 /* CDPlayerComponent.swift in Sources */,
 				87A0D9B1285BAEF8006D0D3B /* Persistence.swift in Sources */,
 				13C0E4A228573795004ABE1D /* RecordDetailView.swift in Sources */,
 				79418F7B2858C17C00F844BD /* ImagePicker.swift in Sources */,

--- a/Record/Views/DetailViews/CDPlayerComponent.swift
+++ b/Record/Views/DetailViews/CDPlayerComponent.swift
@@ -1,0 +1,69 @@
+//
+//  CDPlayerComponent.swift
+//  Record
+//
+//  Created by 이지원 on 2023/03/12.
+//
+
+import SwiftUI
+
+struct CDPlayerComponent: View {
+    
+    @State private var angle = 0.0
+    
+    let music: Music
+
+    var body: some View {
+        ZStack {
+            Image("CdPlayer")
+                .padding(.trailing, 20.0)
+            
+            ZStack(alignment: .center) {
+                Image(uiImage: getImage())
+                    .resizable()
+                    .frame(width: 200, height: 200)
+                    .aspectRatio(contentMode: .fit)
+                    .clipShape(Circle())
+                    .scaleEffect(0.46)
+                    .rotationEffect(.degrees(self.angle))
+                    .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
+                    .onTapGesture {
+                        self.angle += Double.random(in: 3600..<3960)
+                    } // albumArt를 불러오는 URLImage
+                Circle()
+                    .frame(width: 30, height: 30)
+                    .foregroundColor(.background)
+                    .overlay(
+                        Circle()
+                            .stroke(.background, lineWidth: 0.1)
+                            .shadow(color: .titleDarkgray, radius: 2, x: 3, y: 3)
+                    )
+            }.offset(x: -10.6, y: -133) // albumArt를 CD모양으로 불러오는 ZStack
+            
+            ZStack {
+                Circle()
+                    .foregroundColor(.titleLightgray)
+                    .frame(width: 30 , height: 30)
+                Circle()
+                    .foregroundColor(.titleDarkgray)
+                    .frame(width: 15 , height: 15)
+                    .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
+                Circle()
+                    .foregroundColor(.background)
+                    .frame(width: 3 , height: 3)
+            }.offset(x: -10.6, y: -133)
+            
+        }
+    }
+    
+    
+    func getImage() -> UIImage {
+        
+        if let url = URL(string: music.albumArt),
+           let data = try? Data(contentsOf: url) {
+            return UIImage(data: data)!
+        } else {
+            return UIImage(systemName: "xmark")!
+        }
+    }
+}

--- a/Record/Views/DetailViews/PhotoModalView.swift
+++ b/Record/Views/DetailViews/PhotoModalView.swift
@@ -29,17 +29,15 @@ struct PhotoModalView: View {
                         .font(.customTitle2())
                     Spacer()
                     
-                    Button(action: { // 상단 X 버튼
+                    Button {
                         withAnimation {
                             self.isPresented = false
                         }
-                    }) {
+                    } label: {
                         Image(systemName: "xmark")
                             .imageScale(.large)
                             .foregroundColor(.white)
-                    } // 상단 X 버튼 끝
-                    
-                    
+                    }
                 }
                 // 나의 음악 사진 & x 버튼 시작 끝
                 
@@ -56,8 +54,6 @@ struct PhotoModalView: View {
                         .scaledToFill()
                         .padding(.top, 16)
                         .padding(.bottom, 103)
-                    
-                    
                 }
             } // 본문 Frame & Photo 끝
             .frame(minWidth: 0, maxWidth: 308)

--- a/Record/Views/DetailViews/PhotoModalView.swift
+++ b/Record/Views/DetailViews/PhotoModalView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PhotoModalView: View {
     
-    @Environment(\.presentationMode) var presentation
+    @Binding var isPresented: Bool
     let image: Data
 
     var body: some View {
@@ -17,7 +17,9 @@ struct PhotoModalView: View {
             Color.titleBlack //Background Color
                 .opacity(0.95)
                 .ignoresSafeArea()
-            
+                .onTapGesture {
+                    self.isPresented = false
+                }
             VStack {
                 
                 // 나의 음악 사진 & x 버튼 시작
@@ -28,7 +30,9 @@ struct PhotoModalView: View {
                     Spacer()
                     
                     Button(action: { // 상단 X 버튼
-                        presentation.wrappedValue.dismiss()
+                        withAnimation {
+                            self.isPresented = false
+                        }
                     }) {
                         Image(systemName: "xmark")
                             .imageScale(.large)
@@ -37,7 +41,6 @@ struct PhotoModalView: View {
                     
                     
                 }
-                .padding(.horizontal, 48.0)
                 // 나의 음악 사진 & x 버튼 시작 끝
                 
                 // 본문 Frame & Photo 시작
@@ -49,24 +52,19 @@ struct PhotoModalView: View {
                     
                     Image(uiImage: UIImage(data: image)!)
                         .resizable()
-                        .scaledToFill()
                         .frame(minWidth: 0, maxWidth: 276 , minHeight: 0, maxHeight: 314)
-                        .clipped()
+                        .scaledToFill()
                         .padding(.top, 16)
                         .padding(.bottom, 103)
                     
                     
                 }
             } // 본문 Frame & Photo 끝
+            .frame(minWidth: 0, maxWidth: 308)
         }
+        .navigationBarBackButtonHidden(isPresented)
         .onDisappear {
             UIView.setAnimationsEnabled(true)
         }
     }
 }
-//
-//struct PhotoModalView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        PhotoModalView()
-//    }
-//}

--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -18,11 +18,11 @@ struct RecordDetailView: View {
     
     @Binding var item: Content
     
-    @State private var photo = false
-    @State private var story = false
-    @State private var deleteItemAlert = false // delete item alert
-    @State private var saveImage = false
-    @State private var clickEdit = false
+    @State private var isPresentedPhotoView = false
+    @State private var isPresentedStoryView = false
+    @State private var isPresentedDeleteAlert = false
+    @State private var isTappedSaveButton = false
+    @State private var isTappedEditButton = false
     
     var body: some View {
         
@@ -92,7 +92,7 @@ struct RecordDetailView: View {
                                 }
                                 .onTapGesture {
                                     withAnimation {
-                                        photo.toggle()
+                                        isPresentedPhotoView.toggle()
                                     }
                                 }
                                 .padding(.top, UIScreen.getHeight(30))
@@ -113,7 +113,7 @@ struct RecordDetailView: View {
                                 }
                                 .onTapGesture {
                                     withAnimation {
-                                        story.toggle()
+                                        isPresentedStoryView.toggle()
                                     }
                                 }
                                 .fixedSize()
@@ -128,25 +128,25 @@ struct RecordDetailView: View {
             .frame(maxHeight: .infinity, alignment: .topLeading)
             .onTapGesture {
                 withAnimation {
-                    self.photo = false
-                    self.story = false
+                    self.isPresentedPhotoView = false
+                    self.isPresentedStoryView = false
                 }
             }
             
-            if photo, let image = item.image {
-                PhotoModalView(isPresented: $photo, image: image)
+            if isPresentedPhotoView, let image = item.image {
+                PhotoModalView(isPresented: $isPresentedPhotoView, image: image)
             }
             
-            if story, let myStory = item.story {
-                StoryModalView(isPresented: $story, content: myStory)
+            if isPresentedStoryView, let myStory = item.story {
+                StoryModalView(isPresented: $isPresentedStoryView, content: myStory)
             }
         }
-        .navigationBarBackButtonHidden(photo || story)
+        .navigationBarBackButtonHidden(isPresentedPhotoView || isPresentedStoryView)
         .toolbar {
             Menu {
                 // MARK: 편집 기능
                 Button {
-                    clickEdit.toggle()
+                    isTappedEditButton.toggle()
                 } label: {
                     Label("편집", systemImage: "square.and.pencil")
                 }
@@ -160,17 +160,17 @@ struct RecordDetailView: View {
                 
                 // MARK: 삭제 기능
                 Button(role: .destructive) {
-                    deleteItemAlert = true
+                    isPresentedDeleteAlert = true
                 } label: {
                     Label("제거", systemImage: "trash")
                 }
             } label: {
                 Image(systemName: "ellipsis")
                     .padding(.vertical, 10)
-                    .foregroundColor(photo || story ? .clear : .pointBlue)
+                    .foregroundColor(isPresentedPhotoView || isPresentedStoryView ? .clear : .pointBlue)
             }
         }
-        .fullScreenCover(isPresented: $clickEdit) {
+        .fullScreenCover(isPresented: $isTappedEditButton) {
             NavigationView {
                 WriteView(music: Music(artist: item.artist!,
                                        title: item.title!,
@@ -181,14 +181,14 @@ struct RecordDetailView: View {
                 .navigationBarTitleDisplayMode(.inline)
             }
         }
-        .alert("삭제", isPresented: $deleteItemAlert) {
+        .alert("삭제", isPresented: $isPresentedDeleteAlert) {
             Button("삭제", role: .destructive) {
                 PersistenceController.shared.deleteContent(item: item)
                 presentation.wrappedValue.dismiss()
             }
         } message: { Text("정말 삭제하시겠습니까?") }
         // 본문 ZStack End
-            .alert("저장완료", isPresented: $saveImage) {
+            .alert("저장완료", isPresented: $isTappedSaveButton) {
                 Button("확인") {
                 }
             } message: {  }

--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -133,10 +133,8 @@ struct RecordDetailView: View {
                 }
             }
             
-            if photo {
-                if let image = item.image {
-                    PhotoModalView(isPresented: $photo, image: image)
-                }
+            if photo, let image = item.image {
+                PhotoModalView(isPresented: $photo, image: image)
             }
             
             if story {

--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -84,8 +84,7 @@ struct RecordDetailView: View {
                                 
                                 // MARK: Image
                                 ZStack {
-                                    Image("DetailPhotoComp") // 이미지 삽입
-                                        .fullScreenCover(isPresented: $photo, onDismiss: { photo = false }, content: { PhotoModalView(image: item.image!) } )
+                                    Image("DetailPhotoComp")
                                     
                                     if let image = item.image {
                                         Image(uiImage: UIImage(data: image)!)
@@ -98,8 +97,9 @@ struct RecordDetailView: View {
                                     }
                                 }
                                 .onTapGesture {
-                                    photo.toggle()
-                                    UIView.setAnimationsEnabled(false)
+                                    withAnimation {
+                                        photo.toggle()
+                                    }
                                 }
                                 .padding(.top, UIScreen.getHeight(30))
                                 
@@ -118,10 +118,10 @@ struct RecordDetailView: View {
                                         .frame(width: UIScreen.getWidth(130))
                                 }
                                 .onTapGesture {
-                                    story.toggle()
-                                    UIView.setAnimationsEnabled(false)
+                                    withAnimation {
+                                        story.toggle()
+                                    }
                                 }
-                                .fullScreenCover(isPresented: $story, onDismiss: { story = false }, content: { StoryModalView(content: item.story!) } )
                                 .fixedSize()
                                 .offset(x: UIScreen.getWidth(62))
                             }
@@ -132,7 +132,26 @@ struct RecordDetailView: View {
                 }
             }
             .frame(maxHeight: .infinity, alignment: .topLeading)
+            .onTapGesture {
+                withAnimation {
+                    self.photo = false
+                    self.story = false
+                }
+            }
+            
+            if photo {
+                if let image = item.image {
+                    PhotoModalView(isPresented: $photo, image: image)
+                }
+            }
+            
+            if story {
+                if let story = item.story {
+                    StoryModalView(isPresented: $story, content: story)
+                }
+            }
         }
+        .navigationBarBackButtonHidden(photo || story)
         .navigationBarItems(trailing: Menu(content: {
             
             Button(action: { // MARK: 편집 기능
@@ -151,12 +170,14 @@ struct RecordDetailView: View {
                 deleteItemAlert = true
             }, label: {Label("제거", systemImage: "trash")})
             
+            
         }
                                            , label: {
             Image(systemName: "ellipsis")
                 .padding(.vertical, 10)
-                .foregroundColor(.pointBlue)
-        }))// Menu 목록 End
+                .foregroundColor(photo || story ? .clear : .pointBlue)
+        })
+        )// Menu 목록 End
         .fullScreenCover(isPresented: $clickEdit) {
             NavigationView {
                 WriteView(music: Music(artist: item.artist!, title: item.title!, albumArt: item.albumArt!), isWrite: .constant(false) ,isEdit: .constant(true), item: item)

--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -137,10 +137,8 @@ struct RecordDetailView: View {
                 PhotoModalView(isPresented: $photo, image: image)
             }
             
-            if story {
-                if let story = item.story {
-                    StoryModalView(isPresented: $story, content: story)
-                }
+            if story, let myStory = item.story {
+                StoryModalView(isPresented: $story, content: myStory)
             }
         }
         .navigationBarBackButtonHidden(photo || story)

--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -22,15 +22,7 @@ struct RecordDetailView: View {
     @State private var story = false
     @State private var deleteItemAlert = false // delete item alert
     @State private var saveImage = false
-    @State private var clickEdit = false {
-        willSet {
-            UIView.setAnimationsEnabled(true)
-        } didSet {
-            DispatchQueue.main.async {
-                UIView.setAnimationsEnabled(true)
-            }
-        }
-    }
+    @State private var clickEdit = false
     
     var body: some View {
         
@@ -74,7 +66,9 @@ struct RecordDetailView: View {
                         // MARK: CD Player
                         HStack {
                             Spacer()
-                            CDPlayerComp(music: Music(artist: item.artist ?? "", title: item.title ?? "", albumArt: item.albumArt ?? ""))
+                            CDPlayerComponent(music: Music(artist: item.artist ?? "",
+                                                           title: item.title ?? "",
+                                                           albumArt: item.albumArt ?? ""))
                         }
                     }
                     
@@ -152,36 +146,43 @@ struct RecordDetailView: View {
             }
         }
         .navigationBarBackButtonHidden(photo || story)
-        .navigationBarItems(trailing: Menu(content: {
-            
-            Button(action: { // MARK: 편집 기능
-                clickEdit.toggle()
-            }) {
-                Label("편집", systemImage: "square.and.pencil")
+        .toolbar {
+            Menu {
+                // MARK: 편집 기능
+                Button {
+                    clickEdit.toggle()
+                } label: {
+                    Label("편집", systemImage: "square.and.pencil")
+                }
+                
+                // MARK: 이미지 저장 기능
+                Button {
+                    actionSheet()
+                } label: {
+                    Label("이미지 공유", systemImage: "square.and.arrow.up")
+                }
+                
+                // MARK: 삭제 기능
+                Button(role: .destructive) {
+                    deleteItemAlert = true
+                } label: {
+                    Label("제거", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .padding(.vertical, 10)
+                    .foregroundColor(photo || story ? .clear : .pointBlue)
             }
-            
-            // MARK: 이미지 저장 기능
-            Button(action: {
-                actionSheet()
-            }) { Label("이미지 공유", systemImage: "square.and.arrow.up") }
-            
-            // MARK: 삭제 기능
-            Button(role: .destructive, action: {
-                deleteItemAlert = true
-            }, label: {Label("제거", systemImage: "trash")})
-            
-            
         }
-                                           , label: {
-            Image(systemName: "ellipsis")
-                .padding(.vertical, 10)
-                .foregroundColor(photo || story ? .clear : .pointBlue)
-        })
-        )// Menu 목록 End
         .fullScreenCover(isPresented: $clickEdit) {
             NavigationView {
-                WriteView(music: Music(artist: item.artist!, title: item.title!, albumArt: item.albumArt!), isWrite: .constant(false) ,isEdit: .constant(true), item: item)
-                    .navigationBarTitleDisplayMode(.inline)
+                WriteView(music: Music(artist: item.artist!,
+                                       title: item.title!,
+                                       albumArt: item.albumArt!),
+                          isWrite: .constant(false),
+                          isEdit: .constant(true),
+                          item: item)
+                .navigationBarTitleDisplayMode(.inline)
             }
         }
         .alert("삭제", isPresented: $deleteItemAlert) {
@@ -204,67 +205,6 @@ struct RecordDetailView: View {
         let activitiViewController = UIActivityViewController(activityItems: [activityItemMetadata, shareImage], applicationActivities: nil)
         let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
         windowScene?.windows.first?.rootViewController?.present(activitiViewController, animated: true, completion: nil)
-    }
-    
-}
-
-
-struct CDPlayerComp: View {
-    
-    let music: Music
-    @State private var angle = 0.0
-    var body: some View {
-        ZStack {
-            Image("CdPlayer")
-                .padding(.trailing, 20.0)
-            
-            ZStack(alignment: .center) {
-                Image(uiImage: getImage())
-                    .resizable()
-                    .frame(width: 200, height: 200)
-                    .aspectRatio(contentMode: .fit)
-                    .clipShape(Circle())
-                    .scaleEffect(0.46)
-                    .rotationEffect(.degrees(self.angle))
-                    .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
-                    .onTapGesture {
-                        self.angle += Double.random(in: 3600..<3960)
-                    } // albumArt를 불러오는 URLImage
-                Circle()
-                    .frame(width: 30, height: 30)
-                    .foregroundColor(.background)
-                    .overlay(
-                        Circle()
-                            .stroke(.background, lineWidth: 0.1)
-                            .shadow(color: .titleDarkgray, radius: 2, x: 3, y: 3)
-                    )
-            }.offset(x: -10.6, y: -133) // albumArt를 CD모양으로 불러오는 ZStack
-            
-            ZStack {
-                Circle()
-                    .foregroundColor(.titleLightgray)
-                    .frame(width: 30 , height: 30)
-                Circle()
-                    .foregroundColor(.titleDarkgray)
-                    .frame(width: 15 , height: 15)
-                    .shadow(color: Color(.gray), radius: 4, x: 0, y: 4)
-                Circle()
-                    .foregroundColor(.background)
-                    .frame(width: 3 , height: 3)
-            }.offset(x: -10.6, y: -133)
-            
-        }// ZStack End
-    }
-    func getImage() -> UIImage {
-        if let url = URL(string: music.albumArt) {
-            if let data = try? Data(contentsOf: url ) {
-                return UIImage(data: data)!
-            } else {
-                return UIImage(systemName: "xmark")!
-            }
-        } else {
-            return UIImage(systemName: "xmark")!
-        }
     }
 }
 

--- a/Record/Views/DetailViews/StoryModalView.swift
+++ b/Record/Views/DetailViews/StoryModalView.swift
@@ -30,18 +30,15 @@ struct StoryModalView: View {
                         .font(.customTitle2())
                     Spacer()
                     
-                    Button(action: { // 상단 X 버튼
+                    Button {
                         withAnimation {
                             self.isPresented = false
-                            
                         }
-                    }) {
+                    } label: {
                         Image(systemName: "xmark")
                             .imageScale(.large)
                             .foregroundColor(.white)
-                    } // 상단 X 버튼 끝
-                    
-                    
+                    }
                 }
                 .padding(.horizontal, 48.0)
                 // 나의 음악 이야기 & x 버튼 시작 끝

--- a/Record/Views/DetailViews/StoryModalView.swift
+++ b/Record/Views/DetailViews/StoryModalView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct StoryModalView: View {
     
-    @Environment(\.presentationMode) var presentation
+    @Binding var isPresented: Bool
     let content: String
     
     var body: some View {
@@ -17,6 +17,9 @@ struct StoryModalView: View {
             Color.titleBlack //Background Color
                 .opacity(0.95)
                 .ignoresSafeArea()
+                .onTapGesture {
+                    self.isPresented = false
+                }
             
             VStack {
                 
@@ -28,7 +31,10 @@ struct StoryModalView: View {
                     Spacer()
                     
                     Button(action: { // 상단 X 버튼
-                        presentation.wrappedValue.dismiss()
+                        withAnimation {
+                            self.isPresented = false
+                            
+                        }
                     }) {
                         Image(systemName: "xmark")
                             .imageScale(.large)
@@ -57,15 +63,5 @@ struct StoryModalView: View {
                 }
             } // 본문 Frame & Text 끝
         }
-        .onDisappear {
-            UIView.setAnimationsEnabled(true)
-        }
     }
 }
-
-//struct StoryModalView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        StoryModalView()
-//            .previewInterfaceOrientation(.portrait)
-//    }
-//}

--- a/Record/Views/WriteViews/WriteView.swift
+++ b/Record/Views/WriteViews/WriteView.swift
@@ -78,7 +78,6 @@ struct WriteView: View {
                                     .foregroundColor(.titleDarkgray)
                                 
                             }
-                            //                            .padding(.vertical, UIScreen.getHeight(15))
                             
                             // MARK: CD Player
                             HStack {
@@ -148,12 +147,10 @@ struct WriteView: View {
                                         }
                                     }
                                     .onTapGesture {
-                                        savestory.toggle()
-                                        UIView.setAnimationsEnabled(false)
+                                        withAnimation {
+                                            savestory.toggle()
+                                        }
                                     }
-                                    .fullScreenCover(isPresented: $savestory, onDismiss: { savestory = false }, content: {
-                                        WritingModalView(content: $content)
-                                    })
                                     .offset(x: UIScreen.getWidth(62))
                                 }
                                 
@@ -165,6 +162,9 @@ struct WriteView: View {
                 }
                 .frame(maxHeight: .infinity, alignment: .topLeading)
                 
+                if savestory {
+                    WritingModalView(content: $content, isPresented: $savestory)
+                }
             }
             .navigationBarBackButtonHidden(true)
             // 저장 버튼 누르면 Alert 창이 나오고, 홈으로 이동
@@ -182,14 +182,17 @@ struct WriteView: View {
                                         .font(Font.headline.weight(.semibold))
                                     Text("음악 선택")
                                 }
+                                .foregroundColor(savestory ? .clear : .pointBlue)
                             }
                         } else {
-                            Button("닫기", action: {
+                            Button ("닫기") {
                                 presentationMode.wrappedValue.dismiss()
-                            })
+                            }
+                            .foregroundColor(savestory ? .clear : .pointBlue)
                         }
                     }
                 }
+                
                 
                 ToolbarItem(placement: .navigationBarTrailing) {
                     
@@ -209,6 +212,7 @@ struct WriteView: View {
                             self.showingAlert = true
                             
                         }
+                        .foregroundColor(savestory ? .clear : .pointBlue)
                         .alert(isPresented: $showingAlert) {
                             Alert(
                                 title: Text("저장 완료"),

--- a/Record/Views/WriteViews/WriteView.swift
+++ b/Record/Views/WriteViews/WriteView.swift
@@ -83,7 +83,7 @@ struct WriteView: View {
                             // MARK: CD Player
                             HStack {
                                 Spacer()
-                                CDPlayerComp(music: music)
+                                CDPlayerComponent(music: music)
                             }
                         }
                         

--- a/Record/Views/WriteViews/WritingModalView.swift
+++ b/Record/Views/WriteViews/WritingModalView.swift
@@ -10,12 +10,11 @@ import SwiftUI
 
 struct WritingModalView: View {
     
-    @Environment(\.presentationMode) var presentation
-    
     @State var placeholderText : String = "이 음악과 관련된 짧은 이야기를\n기록해보세요 (글자수 200자 제한)"
 
     @Binding var content : String
-
+    @Binding var isPresented: Bool
+    
     var characterLimit = 200
     
     var body: some View {
@@ -23,24 +22,30 @@ struct WritingModalView: View {
             Color.titleBlack //Background Color
                 .opacity(0.95)
                 .ignoresSafeArea()
+                .onTapGesture {
+                    withAnimation {
+                        self.isPresented = false
+                    }
+                }
             
             VStack {
                 
-                // 나의 음악 이야기 & x 버튼 시작
+                // MARK: 상단 텍스트 및 닫기 버튼
                 HStack {
                     Text("나의 음악 이야기") // 상단 나의 음악 이야기 Text 텍스트 출력
                         .foregroundColor(.white)
                         .font(.customTitle2())
                     Spacer()
                     
-                    Button(action: { // 상단 X 버튼
-                        presentation.wrappedValue.dismiss()
-                    }) {
+                    Button {
+                        withAnimation {
+                            self.isPresented = false
+                        }
+                    } label: {
                         Image(systemName: "xmark")
                             .imageScale(.large)
                             .foregroundColor(.white)
-                    } // 상단 X 버튼 끝
-                    
+                    }
                     
                 }
                 .padding(.horizontal, 48.0)
@@ -78,7 +83,6 @@ struct WritingModalView: View {
                         }
                         .padding(.horizontal, 10)
                         .padding(.top, 30)
-                        //.padding(.bottom, 50.0)
                         .frame(width: 320, height: 310)
                         // 이야기 작성 TextEditor & PlaceHoler 끝
                         
@@ -88,7 +92,9 @@ struct WritingModalView: View {
                             Spacer()
                             
                             Button("완료") {
-                                presentation.wrappedValue.dismiss()
+                                withAnimation {
+                                    self.isPresented = false
+                                }
                             }
                             .font(.customSubhead())
                             .disabled(content.isEmpty)
@@ -109,16 +115,13 @@ struct WritingModalView: View {
             
 
         }
-        .onDisappear {
-            UIView.setAnimationsEnabled(true)
-        }
     }
 }
 
-        
+
 struct WritingModalView_Previews: PreviewProvider {
     static var previews: some View {
-        WritingModalView(content: .constant(""))
+        WritingModalView(content: .constant(""), isPresented: .constant(true))
     }
 }
 


### PR DESCRIPTION


## Keychanges
- closes #91
- 기존 Full screen으로 구성되어있던 부분을 Floating view로 수정했습니다.
  - modal보다는 Alert가 적절하지만, 알려주는 뷰는 아니기 때문에 "Floating View"라 부르겠습니다!
  - 해당 Floating view가 활성화되면 네비게이션 아이템들의 색상을 조절하여 유저가 혼란스럽지 않도록 했습니다.
- 애니메이션이 없는 Full screen 형태가 아닌 alert 형태로 수정되었습니다.
  - full screen cover가 사라지면서 set Animation 관련 코드가 필요없어져서 삭제했습니다.
- Style 변경사항
  - 가독성을 위해 후행 클로저 문법을 사용하여 Button, Menu를 수정했습니다.
- Navigation Bar Item -> Tool bar로 변경했습니다.
  - `'navigationBarltems(leading:trailing:' will be deprecated in a future version of iOS: Use toolbar (:) with navigationBarLeading or navigationBarTrailing placement` 


## Screenshots

https://user-images.githubusercontent.com/68676844/224555933-d329c15c-c9e1-4a27-ac18-5fb1d1a5d722.mov



## To Reviewer
- 여전히 특정 뷰 파일에 관련 없는 두 개 이상의 구조체가 존재하는 경우가 있습니다. 분리가 필요하다고 생각합니다!
- 현재 Binding을 사용하고 있기 때문에 X 버튼을 눌러도 취소가 아니고 저장되는 형태입니다. 혼란을 야기하지는 않을까요?
  - 즉, 완료 버튼, X 버튼, 포스트잇 외부 뷰를 터치했을 때 모두 같은 같은 동작을 수행합니다. 저는 x 버튼을 누를 때에나 외부 뷰를 터치했을 때 경고창과 함께 글이 삭제되어야한다고 생각하는데, 여러분의 생각은 어떠신가요?
