### PR TITLE
[Feat] 음악 재생 기능 추가

### DIFF
--- a/Record/Model/MusicAPI.swift
+++ b/Record/Model/MusicAPI.swift
@@ -48,11 +48,12 @@ final class MusicAPI: ObservableObject {
                     let searchResults = jsonObject["results"] as! [NSDictionary]
                     searchResults.forEach { result in
                         
-                        
                         // Music 객체에 저장
                         let searchResult = Music(artist: result["artistName"] as! String,
                                                  title: result["trackName"] as! String,
-                                                 albumArt: (result["artworkUrl100"] as! String).replacingOccurrences(of: "100x100bb", with: "500x500bb"))
+                                                 albumArt: (result["artworkUrl100"] as! String).replacingOccurrences(of: "100x100bb", with: "500x500bb"),
+                                                 previewUrl: result["previewUrl"] as! String)
+                        
                         
                         self.musicList.append(searchResult)
                     }
@@ -67,6 +68,7 @@ final class MusicAPI: ObservableObject {
         
         task.resume()
     }
+    
 }
 
 
@@ -75,4 +77,5 @@ struct Music: Hashable, Codable {
     var artist: String // 가수
     var title: String // 제목
     var albumArt: String //앨범커버
+    var previewUrl: String? // 1분 미리듣기
 }

--- a/Record/Model/Record.xcdatamodeld/Recored.xcdatamodel/contents
+++ b/Record/Model/Record.xcdatamodeld/Recored.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Content" representedClassName="Content" syncable="YES" codeGenerationType="class">
         <attribute name="albumArt" attributeType="String"/>
         <attribute name="artist" attributeType="String"/>
@@ -7,10 +7,8 @@
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="image" attributeType="Binary" customClassName="UIImage"/>
         <attribute name="lyrics" attributeType="String"/>
+        <attribute name="previewUrl" optional="YES" attributeType="String"/>
         <attribute name="story" attributeType="String"/>
         <attribute name="title" attributeType="String"/>
     </entity>
-    <elements>
-        <element name="Content" positionX="-54" positionY="-9" width="128" height="149"/>
-    </elements>
 </model>

--- a/Record/Views/DetailViews/CDPlayerComponent.swift
+++ b/Record/Views/DetailViews/CDPlayerComponent.swift
@@ -6,13 +6,15 @@
 //
 
 import SwiftUI
+import AVKit
 
 struct CDPlayerComponent: View {
     
     @State private var angle = 0.0
-    
+    @State var player: AVPlayer?
+    @State var isPlayMusic: Bool = false
     let music: Music
-
+    
     var body: some View {
         ZStack {
             Image("CdPlayer")
@@ -28,6 +30,11 @@ struct CDPlayerComponent: View {
                     .rotationEffect(.degrees(self.angle))
                     .animation(.timingCurve(0, 0.8, 0.2, 1, duration: 10), value: angle)
                     .onTapGesture {
+                        if isPlayMusic {
+                            pauseMusic()
+                        } else {
+                            playMusic()
+                        }
                         self.angle += Double.random(in: 3600..<3960)
                     } // albumArt를 불러오는 URLImage
                 Circle()
@@ -54,8 +61,8 @@ struct CDPlayerComponent: View {
             }.offset(x: -10.6, y: -133)
             
         }
+        
     }
-    
     
     func getImage() -> UIImage {
         
@@ -65,5 +72,28 @@ struct CDPlayerComponent: View {
         } else {
             return UIImage(systemName: "xmark")!
         }
+        
+    }
+    
+    func playMusic() {
+       
+        isPlayMusic.toggle()
+        
+        let musicURL = URL.init(string: music.previewUrl ?? "")
+        
+        guard let url = musicURL else {
+            debugPrint("Music url is not valid")
+            return
+        }
+        
+        player = AVPlayer(playerItem: AVPlayerItem(url: url))
+        
+        player?.play()
+        
+    }
+    
+    func pauseMusic() {
+        isPlayMusic.toggle()
+        player?.pause()
     }
 }

--- a/Record/Views/DetailViews/RecordDetailView.swift
+++ b/Record/Views/DetailViews/RecordDetailView.swift
@@ -70,7 +70,8 @@ struct RecordDetailView: View {
                             Spacer()
                             CDPlayerComponent(music: Music(artist: item.artist ?? "",
                                                            title: item.title ?? "",
-                                                           albumArt: item.albumArt ?? ""))
+                                                           albumArt: item.albumArt ?? "",
+                                                           previewUrl: item.previewUrl ?? ""))
                         }
                     }
                     
@@ -175,7 +176,8 @@ struct RecordDetailView: View {
             NavigationView {
                 WriteView(music: Music(artist: item.artist!,
                                        title: item.title!,
-                                       albumArt: item.albumArt!),
+                                       albumArt: item.albumArt!,
+                                       previewUrl: item.previewUrl),
                           isWrite: .constant(false),
                           isEdit: .constant(true),
                           item: item)

--- a/Record/Views/WriteViews/WriteView.swift
+++ b/Record/Views/WriteViews/WriteView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AVKit
 
 struct WriteView: View {
     
@@ -208,6 +209,7 @@ struct WriteView: View {
                             item!.image = inputImage!.jpegData(compressionQuality: 1)
                             item!.lyrics = lyrics
                             
+                            
                             PersistenceController.shared.saveContent()
                             self.showingAlert = true
                             
@@ -244,6 +246,7 @@ struct WriteView: View {
             item!.title = music.title
             item!.artist = music.artist
             item!.albumArt = music.albumArt
+            item!.previewUrl = music.previewUrl
             
         }
     } // View End
@@ -287,6 +290,6 @@ struct NavigationUtil {
 
 struct WriteView_Previews: PreviewProvider {
     static var previews: some View {
-        WriteView(music: Music(artist: "가수이름", title: "노래제목", albumArt: "https://is3-ssl.mzstatic.com/image/thumb/Music122/v4/f7/68/9c/f7689ce3-6d41-60cd-62d2-57a91ddf5b9d/196922067341_Cover.jpg/100x100bb.jpg"), isWrite: .constant(true), isEdit: .constant(false))
+        WriteView(music: Music(artist: "가수이름", title: "노래제목", albumArt: "https://is3-ssl.mzstatic.com/image/thumb/Music122/v4/f7/68/9c/f7689ce3-6d41-60cd-62d2-57a91ddf5b9d/196922067341_Cover.jpg/100x100bb.jpg", previewUrl: "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/ca/b2/31/cab231b4-58d5-ceba-f895-327365f30e6f/mzaf_6692739326647302071.plus.aac.p.m4a"), isWrite: .constant(true), isEdit: .constant(false))
     }
 }


### PR DESCRIPTION
## Keychanges
- #112 
- 음악 플레이어 view 클릭시 재생 및 정지 


## Screenshots
iPhone13, WriteView

https://github.com/DeveloperAcademy-POSTECH/MC2-Team7-Larasy/assets/66102708/aacd416a-b50c-4bed-923d-6205abfaf29e


## To Reviewer
- 음악을 정지 시킨 후 다시 재생하면 처음부터 음악이 재생되게 됩니다.
- 음악이 재생되는 동안 cd 플레이어의 애니메이션이 천천히 돌아가면서 유지하는게 좋을지 의견 부탁드립니다.



